### PR TITLE
Setup GitHub Actions to run install-dev.sh and test.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,21 +17,24 @@ jobs:
         python-version: [3.9]
 
     steps:
-    - name: Check out repository
-      uses: actions/checkout@v2
+      - name: Check out repository
+        uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y python3-pip
-        pip install --upgrade pip
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y python3-pip
+          pip install --upgrade pip
 
-    - name: Run install-dev.sh
-      run: ./install-dev.sh
+      - name: Make install-dev.sh executable
+        run: chmod +x ./*.sh
 
-    - name: Run tests
-      run: ./test.sh
+      - name: Run install-dev.sh
+        run: ./install-dev.sh
+
+      - name: Run tests
+        run: ./test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y python3-pip
+        pip install --upgrade pip
+
+    - name: Run install-dev.sh
+      run: ./install-dev.sh
+
+    - name: Run tests
+      run: ./test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
           sudo apt-get install -y python3-pip
           pip install --upgrade pip
 
+      - name: Install dependencies
+        run: |
+          pip install build setuptools wheel
+
       - name: Make install-dev.sh executable
         run: chmod +x ./*.sh
 

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -1,3 +1,4 @@
-#!/bin/sh
+#!/bin/bash
+set -e
 ./build.sh
 pip3 install --editable .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [{name="Bee Wilkerson", email="bee.wilkerson@ymail.com" }]
 description = "A simpler alternative to ROS"
 readme = "README.md"
 dependencies = [
+    "build",
     "cachetools",
     "requests",
     "websockets==10.4",


### PR DESCRIPTION
The first commit belongs to GitHub workspaces, generated from the prompt:
```
I want to setup github actions to run the install-dev.sh and run the test.sh file in the root.  I would like for the install and test to run in python 3.9 and linux distribution container.
```

Let's see how this goes.

Three changes later and we have build and test actions on every PR!  Note that the `e2e_tests/create_test` task takes 30 seconds because it is calling `bb_create test_project` from a temp dir and `bb_create` also runs the tests included with the created files, so you have like double layer testing as well.  I can sleep at night now if others are using this.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/littlebee/basic_bot/pull/7?shareId=a9c3441e-44fc-4147-82c8-3c53e55cf412).