### PR TITLE
Be explicit about python3 vs python

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ First `ssh` into the onboard computer and `cd path/uploaded/to`.
 
 Before running for the first time, in an ssh shell, install the basic_bot package:
 ```
-python -m pip install git+https://github.com/littlebee/basic_bot.git@main
+python3 -m pip install git+https://github.com/littlebee/basic_bot.git@main
 ```
 
 Then from within the the directory you uploaded to:

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python -m build
+python3 -m build

--- a/src/basic_bot/start.py
+++ b/src/basic_bot/start.py
@@ -92,7 +92,7 @@ def main():
 
         print(f"Starting {sub_system}...")
 
-        args = ["python", "-m", sub_system] if is_module else ["python3", sub_system]
+        args = ["python3", "-m", sub_system] if is_module else ["python3", sub_system]
 
         with open(log_file, "w") as log, open(pid_file, "w") as pid:
             process = subprocess.Popen(args, stdout=log, stderr=log)

--- a/src/basic_bot/stop.py
+++ b/src/basic_bot/stop.py
@@ -4,7 +4,7 @@ import sys
 import signal
 
 HELP = """
-Usage: python -m basic_bot.stop [service] [service] ...
+Usage: python3 -m basic_bot.stop [service] [service] ...
 
 [service] is optional.  If not specified, all services listed in services.cfg in reverse order.
 """


### PR DESCRIPTION
Doing testing on older macbooks I have around.  The command for starting python needs to be `python3`.

Older macOS (testing on Sonoma) is still at python 2.7(?)  I installed 3.9 from brew but /usr/bin/python still pointed at older python version.

