### PR TITLE
Add on_connect callback for hub_state_monitor

### DIFF
--- a/tests/integration_tests/test_hub_state_monitor.py
+++ b/tests/integration_tests/test_hub_state_monitor.py
@@ -73,3 +73,20 @@ class TestHubStateMonitor:
         finally:
             # must do this at the end to stop the monitor
             monitor.stop()
+
+    def test_on_connect(self):
+
+        on_connect = Mock()
+        monitor = HubStateMonitor(
+            hub_state=HubState({"foo": 0}),
+            identity="TestHubStateMonitor-test_hub_state_monitor-hub",
+            subscribed_keys=["foo"],
+            on_connect=on_connect,
+        )
+        monitor.start()
+
+        try:
+            time.sleep(EXPECTED_LATENCY)
+            on_connect.assert_called_once_with(monitor.connected_socket)
+        finally:
+            monitor.stop()


### PR DESCRIPTION
this is necessary and can be used by publishers to publish their current state that they are the sole provider