### PR TITLE
bb_restart should use bb_start and bb_stop

### DIFF
--- a/src/basic_bot/bb_restart.py
+++ b/src/basic_bot/bb_restart.py
@@ -8,13 +8,13 @@ import sys
 def main(args):
     try:
         print("Stopping services")
-        subprocess.run(["./stop.sh"] + args, check=True)
+        subprocess.run("bb_stop " + args, check=True)
 
         print("Sleeping for 5s")
         time.sleep(5)
 
         print("Starting services")
-        subprocess.run(["./start.sh"] + args, check=True)
+        subprocess.run("bb_start " + args, check=True)
     except subprocess.CalledProcessError as e:
         print(f"An error occurred: {e}")
         sys.exit(1)

--- a/src/basic_bot/bb_start.py
+++ b/src/basic_bot/bb_start.py
@@ -68,7 +68,7 @@ def main():
             print(
                 f"\nCowardly refusing to overwrite {pid_file}. \n"
                 f"Is {sub_system} already running? If so,  try running \n\n"
-                f'basic_bot_stop "-m {sub_system}" \n\n'
+                f'bb_stop "-m {sub_system}" \n\n'
                 "from the terminal or if not, delete the pid file and try again.\n"
             )
             continue

--- a/src/basic_bot/services/vision_cv2.py
+++ b/src/basic_bot/services/vision_cv2.py
@@ -134,7 +134,7 @@ class webapp:
         self.camera = camera
 
     def thread(self):
-        log(f"starting vision webhost on {c.BB_VISION_PORT}")
+        log.info(f"starting vision webhost on {c.BB_VISION_PORT}")
         app.run(host="0.0.0.0", port=c.BB_VISION_PORT, threaded=True)
 
     def start_thread(self):

--- a/src/basic_bot/start.py
+++ b/src/basic_bot/start.py
@@ -68,7 +68,7 @@ def main():
             print(
                 f"\nCowardly refusing to overwrite {pid_file}. \n"
                 f"Is {sub_system} already running? If so,  try running \n\n"
-                f'basic_bot_stop "-m {sub_system}" \n\n'
+                f'bb_stop "-m {sub_system}" \n\n'
                 "from the terminal or if not, delete the pid file and try again.\n"
             )
             continue


### PR DESCRIPTION
bb_restart should not use the ./start.sh and ./stop.sh scripts from the cwd.

also:
- change outdated console output referencing using basic_bot_start and .._stop
- fix log not callable error