### PR TITLE
Make flake8 official Python linter

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,10 @@ rm -Rf src/basic_bot/created_files/webapp/package-lock.json
 # fail on any error
 set -e
 
-echo "Running mypy $(python3 -m mypy --version)"
+echo "Linting..."
+python3 -m flake8 src/basic_bot
+
+echo "Running mypy \(typechecker\): $(python3 -m mypy --version)"
 python3 -m mypy src/basic_bot
 
 echo "Building package"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+flake8
 pytest
 mypy
 types-Flask-Cors

--- a/src/basic_bot/commons/persist_state.py
+++ b/src/basic_bot/commons/persist_state.py
@@ -2,7 +2,7 @@ import os
 import json
 from typing import List
 
-from basic_bot.commons import log, constants as c
+from basic_bot.commons import log
 from basic_bot.commons.hub_state import HubState
 
 


### PR DESCRIPTION
I have been using flake8 plugin for vscode for a while and the project already had a flake8 config.  Because of that, there was only one error which I noticed highlighted in the editor and decided to make it an official part of the build which includes CI/CD