### PR TITLE
Add global scripts for bb_ps and bb_killall

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "daphbot",
         "fourcc",
         "inlinehilite",
+        "killall",
         "linenums",
         "Matlike",
         "Picamera",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,13 @@ dependencies = [
     "opencv-python>=4.11",
     "psutil",
     "pytest",
+    "pyyaml",
     "protobuf>=3.18.0,<4",
     # tflite-runtime is currently only supported on Linux
     "tflite-runtime; platform_system=='Linux'",
     # TODO: move to requirements.txt?  I think this is only used for
     #   the basic_bot integrations tests
     "websocket-client",
-    "pyyaml",
 ]
 # These are the dependencies of the installed basic_bot package
 #  for dev / build dependencies, use `pip install -r requirements.txt`
@@ -38,6 +38,8 @@ requires-python = ">=3.9"
 bb_create = "basic_bot.bb_create:main"
 bb_start = "basic_bot.bb_start:main"
 bb_stop = "basic_bot.bb_stop:main"
+bb_ps = "basic_bot.bb_ps:main"
+bb_killall = "basic_bot.bb_killall:main"
 
 
 [project.urls]

--- a/src/basic_bot/README.md
+++ b/src/basic_bot/README.md
@@ -1,0 +1,14 @@
+# basic_bot scripts
+
+The scripts in this directory are used to manage your basic_bot project.  They are installed in the path by pip install of basic_bot.
+
+[bb_create](https://littlebee.github.io/basic_bot/Api%20Docs/scripts/bb_create/) - create a new basic_bot project.  See also [Getting Started](https://littlebee.github.io/basic_bot/#getting-started)
+
+[bb_start](https://littlebee.github.io/basic_bot/Api%20Docs/scripts/bb_start/) - starts all of the services in the current directory's `basic_bot.yml` file.
+
+[bb_stop](https://littlebee.github.io/basic_bot/Api%20Docs/scripts/bb_stop/) - stops all of the services in the current directory's `basic_bot.yml` file.
+
+[bb_ps](https://littlebee.github.io/basic_bot/Api%20Docs/scripts/bb_ps/) - list all processes started by `bb_start` from anywhere.
+
+[bb_killall](https://littlebee.github.io/basic_bot/Api%20Docs/scripts/bb_killall/) - kill all processes started by `bb_start` from anywhere.
+

--- a/src/basic_bot/bb_killall.py
+++ b/src/basic_bot/bb_killall.py
@@ -1,18 +1,28 @@
 #!/usr/bin/env python3
 """
 Finds all processes started by bb_start and kills them with signal 15.
-It also removes all files in the local pids directory.
+It also removes all files in the local pids directory if they exist.
+
+This script differs from `bb_stop` in that it works more like the *nix
+`killall` command, which sends a signal to all processes that match a
+query.   It does not discriminate based on any `basic_bot.yml` file
+like `bb_stop` does.
+
+See also: `bb_ps` script.
+
+bb_killall is a script installed in the path by pip install of basic_bot.
 
 usage:
 ```sh
-python -m src.basic_bot.debug.killall_bb_procs
+bb_killall
 ```
 """
 import os
 import psutil
 import signal
 
-if __name__ == "__main__":
+
+def main():
     matching_processes = []
     for process in psutil.process_iter(["pid", "name", "cmdline"]):
         try:
@@ -37,3 +47,7 @@ if __name__ == "__main__":
     # remove all files in the pids directory
     for pid_file in os.listdir("./pids"):
         os.remove(f"./pids/{pid_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/basic_bot/bb_ps.py
+++ b/src/basic_bot/bb_ps.py
@@ -6,14 +6,17 @@ When `bb_start` is used to start a process, it adds a `via=bb_start` to the
 command line. You can also see the list of processes started by `bb_start` by
 using `ps -ef | grep "via=bb_start"` from the terminal.
 
+bb_ps is a script installed in the path by pip install of basic_bot.
+
 usage:
 ```sh
-python -m src.basic_bot.debug.ps_bb_procs
+bb_ps
 ```
 """
 import psutil
 
-if __name__ == "__main__":
+
+def main():
     matching_processes = []
     for process in psutil.process_iter(["pid", "name", "cmdline"]):
         try:
@@ -26,10 +29,13 @@ if __name__ == "__main__":
             pass
 
     if matching_processes:
-        print("Found processes started by bb_start:")
         for process in matching_processes:
             print(
                 f"PID: {process.pid}, Name: {process.name()}, Command: {' '.join(process.cmdline())}"
             )
     else:
-        print("No processes found matching the regex.")
+        print("No processes found with 'via=bb_start'.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/basic_bot/created_files/ps.sh
+++ b/src/basic_bot/created_files/ps.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-python -m basic_bot.debug.ps_bb_procs

--- a/src/basic_bot/debug/README.md
+++ b/src/basic_bot/debug/README.md
@@ -1,5 +1,5 @@
 
-# basic_bot.debug
+# basic_bot.debug package index
 
 This package is a collection of individual test programs meant to validate the correct setup and installation of 3rd party packages like opencv and tensorflow.
 

--- a/src/basic_bot/services/README.md
+++ b/src/basic_bot/services/README.md
@@ -1,0 +1,12 @@
+# basic_bot services
+
+These are the services that come with basic_bot.  Many are hardware dependent.  Some require additional drivers installed.  See documentation for each service to learn more about what it requires and provides.
+
+[central_hub](https://littlebee.github.io/basic_bot/Api%20Docs/services/central_hub/) is the only service that must be started.  It provides an under 5ms roundtrip latency pub/sub service that the other services communicate state through.
+
+[web_server](https://littlebee.github.io/basic_bot/Api%20Docs/services/web_server/) is an optional service that serves a web UI from your robot.
+
+[vision](https://littlebee.github.io/basic_bot/Api%20Docs/services/vision/) provides live video streaming and in-frame object detection and classification.
+
+[motor_control_2w](https://littlebee.github.io/basic_bot/Api%20Docs/services/motor_control_2w/) provides motor control of a 2 wheel or track drive mobile robot.
+


### PR DESCRIPTION

I find myself at least once a day when developing wanting to know what basic_bot services are running.  As part of  the config work, I added an identifier to all processes that were started by bb_start.  I also added basic_bot.debug scripts that could be awkwardly used like `python -m basic_bot.debug.killall_bb_procs`.   

This PR moves the two scripts into the basic_bot base scripts that get installed in the path by pip install of basic_bot.  You can now simply use:
```sh
bb_ps
```
to get a list of all running basic_bot services.  And...
```sh
bb_killall
```
will kill (SIGTERM) all of the processes.
