### PR TITLE
Tighten schema constraints on env vars in basic_bot.yml

### DIFF
--- a/basic_bot.yml
+++ b/basic_bot.yml
@@ -6,7 +6,7 @@ version: "0.1.0"
 # environment variables.  Service environment variables
 # will override these if they have the same key.
 env:
-  BB_LOG_ALL_MESSAGES: false
+  BB_LOG_ALL_MESSAGES: "false"
 
 services:
   - name: "central_hub"

--- a/src/basic_bot/bb_start.py
+++ b/src/basic_bot/bb_start.py
@@ -107,7 +107,8 @@ def start_service(
     # `ps aux | grep via=bb_start``
     args.append("via=bb_start")
     # must include full environment if env arg to Popen is used
-    env = os.environ.copy().update(service_env)
+    env = {**os.environ, **service_env}
+    # print(f" Combined env: {env}")
 
     with open(log_file, "w") as log:
         process = subprocess.Popen(args, stdout=log, stderr=log, env=env)
@@ -159,7 +160,7 @@ def main() -> None:
     except yaml.YAMLError:
         print(f"Error: Invalid YAML syntax: {args.file}")
     except ValidationError as e:
-        print(f"Config file validation error: {e.message}")
+        print(f"Config file validation error: {e}")
 
 
 if __name__ == "__main__":

--- a/src/basic_bot/bb_start.py
+++ b/src/basic_bot/bb_start.py
@@ -31,7 +31,7 @@ import yaml
 from jsonschema import validate, ValidationError
 
 
-from typing import Optional, Mapping
+from typing import Optional, Dict
 
 
 from basic_bot.commons.script_helpers.pid_files import is_pid_file_valid
@@ -77,7 +77,7 @@ def start_service(
     run_cmd: str,
     log_file: Optional[str] = None,
     pid_file: Optional[str] = None,
-    service_env: Mapping[str, str] = {},
+    service_env: Dict[str, str] = {},
 ) -> None:
     log_file = log_file or f"./logs/{service_name}.log"
     pid_file = pid_file or f"./pids/{service_name}.pid"

--- a/src/basic_bot/commons/config_file_schema.py
+++ b/src/basic_bot/commons/config_file_schema.py
@@ -23,14 +23,20 @@ config_file_schema = {
         #
         # Environment variables that are set for all services started unless
         # overridden by the service `env' property.
-        "env": {"type": "object"},
+        "env": {"type": "object", "additionalProperties": {"type": "string"}},
         #
         # Environment variables that are set for all services started unless
         # overridden by the service `env' property. These are merged with the
         # `env` property
-        "test_env": {"type": "object"},
-        "production_env": {"type": "object"},
-        "development_env": {"type": "object"},
+        "test_env": {"type": "object", "additionalProperties": {"type": "string"}},
+        "production_env": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
+        "development_env": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
         #
         # List of services to start.  Each service is started in the background
         # as a detached process.
@@ -62,15 +68,27 @@ config_file_schema = {
                     # Environment variables that are set for this service. These
                     # are merged with the `env` properties for the overall
                     # configuration above.  These are the penultimate environmen.
-                    "env": {"type": "object"},
+                    "env": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
                     #
                     # Environment variables that are set for this service in the
                     # test, production and development  environments.
                     # These are merged with the `env`s above and are the
                     # ultimate environment variables.
-                    "test_env": {"type": "object"},
-                    "production_env": {"type": "object"},
-                    "development_env": {"type": "object"},
+                    "test_env": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "production_env": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    "development_env": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
                 },
             },
         },

--- a/src/basic_bot/services/vision.py
+++ b/src/basic_bot/services/vision.py
@@ -62,11 +62,11 @@ from typing import Generator
 # mock camera which provides random images that should
 # be half with pet in image and half without pet in image
 if c.BB_ENV == "test":
-    log.info("Running in test mode, using camera_mock")
     camera_lib = "basic_bot.test_helpers.camera_mock"
 else:
     camera_lib = c.BB_CAMERA_MODULE
 
+log.info(f"loading camera module: {camera_lib}")
 camera_module = importlib.import_module(camera_lib)
 camera = camera_module.Camera()  # type: ignore
 

--- a/src/basic_bot/test_helpers/start_stop.py
+++ b/src/basic_bot/test_helpers/start_stop.py
@@ -1,6 +1,6 @@
 import os
 
-from typing import Tuple, Mapping
+from typing import Tuple, Dict
 
 from basic_bot import bb_start, bb_stop
 
@@ -11,7 +11,7 @@ def get_files_for_service(service_name: str) -> Tuple[str, str]:
     return log_file, pid_file
 
 
-def start_service(service_name: str, run_cmd: str, env: Mapping[str, str] = {}) -> None:
+def start_service(service_name: str, run_cmd: str, env: Dict[str, str] = {}) -> None:
     """
     Starts requested service using bb_start command.  This is useful
     for integration and e2e tests.
@@ -28,7 +28,7 @@ def start_service(service_name: str, run_cmd: str, env: Mapping[str, str] = {}) 
 
         run_cmd = the command to start the service.
     """
-    updated_env: Mapping[str, str] = {**env, "BB_ENV": "test"}
+    updated_env: Dict[str, str] = {**env, "BB_ENV": "test"}
     log_file, pid_file = get_files_for_service(service_name)
     bb_start.start_service(
         f"test_{service_name}", run_cmd, log_file, pid_file, updated_env

--- a/tests/integration_tests/test_system_stats.py
+++ b/tests/integration_tests/test_system_stats.py
@@ -13,7 +13,7 @@ def setup_module():
     sst.start_service(
         "system_stats",
         "python -m basic_bot.services.system_stats",
-        {"BB_SYSTEM_STATS_SAMPLE_INTERVAL": TEST_SAMPLE_INTERVAL},
+        {"BB_SYSTEM_STATS_SAMPLE_INTERVAL": str(TEST_SAMPLE_INTERVAL)},
     )
 
 
@@ -25,38 +25,37 @@ def teardown_module():
 class TestSystemStats:
     def test_system_stats(self):
         ws = hub.connect()
-        try:
-            hub.send_identity(ws, "system stats test")
-            hub.send_subscribe(ws, ["system_stats"])
+        hub.send_identity(ws, "system stats test")
+        hub.send_subscribe(ws, ["system_stats"])
 
-            response = hub.recv(ws)
-            assert response["type"] == "iseeu"
+        response = hub.recv(ws)
+        assert response["type"] == "iseeu"
 
-            # after the first iseeu message all messages should be state updates
+        # after the first iseeu message all messages should be state updates
 
-            last_host_name = None
-            for _i in range(5):
-                message = hub.recv(ws)
-                assert message["type"] == "stateUpdate"
+        last_host_name = None
+        for _i in range(5):
+            message = hub.recv(ws)
+            assert message["type"] == "stateUpdate"
 
-                cpu_util = message["data"]["system_stats"]["cpu_util"]
-                assert cpu_util >= 0
-                assert cpu_util <= 100
+            cpu_util = message["data"]["system_stats"]["cpu_util"]
+            assert cpu_util >= 0
+            assert cpu_util <= 100
 
-                # Doing this test on the CI/CD runner is not reliable
-                #   because the running environment is reporting the
-                #   CPU utilization of the runner itself, not the service.
-                # assert cpu_util != last_cpu_util
-                # last_cpu_util = cpu_util
+            # Doing this test on the CI/CD runner is not reliable
+            #   because the running environment is reporting the
+            #   CPU utilization of the runner itself, not the service.
+            # assert cpu_util != last_cpu_util
+            # last_cpu_util = cpu_util
 
-                host_name = message["data"]["system_stats"]["hostname"]
-                assert host_name
-                if last_host_name:
-                    assert host_name == last_host_name, "host name should not change"
-                last_host_name = host_name
+            host_name = message["data"]["system_stats"]["hostname"]
+            assert host_name
+            if last_host_name:
+                assert host_name == last_host_name, "host name should not change"
+            last_host_name = host_name
 
-                # as long as the service sleeps the same amount of time that
-                # the test sleeps we should get a new system stats message each time
-                time.sleep(TEST_SAMPLE_INTERVAL)
-        finally:
-            ws.close()
+            # as long as the service sleeps the same amount of time that
+            # the test sleeps we should get a new system stats message each time
+            time.sleep(TEST_SAMPLE_INTERVAL)
+
+        ws.close()


### PR DESCRIPTION
Values should only be specified as strings as real env vars are presented.

