### PR TITLE
Default tflite threads to 3

### DIFF
--- a/src/basic_bot/commons/constants.py
+++ b/src/basic_bot/commons/constants.py
@@ -192,11 +192,18 @@ BB_TFLITE_MODEL_CORAL = env.env_string(
 """
 
 # number of threads to use for tflite detection
-BB_TFLITE_THREADS = env.env_int("BB_TFLITE_THREADS", 2)
+BB_TFLITE_THREADS = env.env_int("BB_TFLITE_THREADS", 3)
 """
-    default: 2
+    default: 3
 
-    Number of threads to use for tflite detection.
+    Number of threads to use for tflite detection.  Testing object detection
+    on a Rasberry PI 5, without any other CPU or memory pressure, 4 tflite threads
+    was only 1 fps faster (29.5fps) than 3 threads (28.6fps).  2 threads was 22fps.
+
+    Warning: Setting this too high can actually reduce the object detection  frame rate.
+    In the case of daphbot_due, which has a [pygame based onboard UI service](https://github.com/littlebee/daphbot-due/blob/main/src/onboard_ui_service.py)
+    that has a configurable render frame rate, the tflite detection running on 4 threads
+    was reduced to about 12 fps when the render frame rate was set to 30fps.
 """
 
 # http port used by the vision service for video streaming

--- a/src/basic_bot/commons/fps_stats.py
+++ b/src/basic_bot/commons/fps_stats.py
@@ -6,7 +6,8 @@ FPS_WINDOW = 60
 
 class FpsStats:
     """
-    FpsStats - A class to track overall and floating frames per seconds
+    FpsStats - A class to track overall and floating frames per seconds.  Floating fps is
+    calculated over the last 60 seconds.
 
     Instantiate the class to start tracking the stats. Call increment() for each frame read.
     Call stats() to get the stats.

--- a/src/basic_bot/commons/tflite_detect.py
+++ b/src/basic_bot/commons/tflite_detect.py
@@ -39,10 +39,14 @@ class TFLiteDetect:
         if model.startswith("./"):
             model = os.path.join(os.path.dirname(__file__), model[2:])
 
-        log.info(f"TFliteDetect using model={model}, use_coral_tpu={use_coral_tpu}")
+        log.info(
+            f"TFliteDetect using model={model}, use_coral_tpu={use_coral_tpu}, num_threads={c.BB_TFLITE_THREADS}"
+        )
 
         # Load TFLite model and allocate tensors.
-        self.interpreter = tflite.Interpreter(model_path=model, num_threads=4)
+        self.interpreter = tflite.Interpreter(
+            model_path=model, num_threads=c.BB_TFLITE_THREADS
+        )
         self.interpreter.allocate_tensors()
 
         self.input_details = self.interpreter.get_input_details()


### PR DESCRIPTION
After extensive testing on Pi5 with daphbot-due onboard_ui running at various render fps, I have concluded that 3 is the optimal number of tflite threads for that SBC.  See comments and doc comments included.

See also, https://github.com/littlebee/daphbot-due/pull/13
