### PR TITLE
reduce console output during webapp tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # our stuff
-/logs/
-/pids/
+logs/
+pids/
 
 node_modules/
 package-lock.json

--- a/src/basic_bot/created_files/webapp/src/App.test.tsx
+++ b/src/basic_bot/created_files/webapp/src/App.test.tsx
@@ -29,7 +29,7 @@ describe("App", () => {
     let hubClient: CentralHubTestClient;
 
     beforeAll(async () => {
-        hubClient = new CentralHubTestClient("App.test.tsx");
+        hubClient = new CentralHubTestClient("app-test");
         await hubClient.startTestHub();
     });
 

--- a/src/basic_bot/created_files/webapp/testHelpers/centralHub.ts
+++ b/src/basic_bot/created_files/webapp/testHelpers/centralHub.ts
@@ -38,10 +38,10 @@ export class CentralHubTestClient {
     }
 
     async startTestHub() {
-        // start all of the services used by the bot
+        // start actual central_hub service
         const cmd = `cd .. && ${this.getEnvVars()} bb_start -s central_hub`;
         console.log(
-            `startTestHub: starting central with command '${cmd}.  threadId: ${process.env.VITEST_POOL_ID}`
+            `startTestHub: starting central with command '${cmd}.  test thread: ${process.env.VITEST_POOL_ID}`
         );
         const { stdout, stderr } = await execAsync(cmd);
         console.log(`startTestHub: stdout: ${stdout}`);
@@ -85,12 +85,7 @@ export class CentralHubTestClient {
                     "central_hub test client timed out waiting for next message"
                 );
             }, 5000);
-            console.log("centralHub test client setting nextMessageWaiter");
             this.nextMessageWaiter = (nextMessage) => {
-                console.log(
-                    "centralHub test client got next message",
-                    nextMessage
-                );
                 clearTimeout(interval);
                 resolve(nextMessage);
             };
@@ -110,11 +105,7 @@ export class CentralHubTestClient {
             return;
         }
 
-        console.log(
-            "centralHub test client got message",
-            parsedMessage,
-            Object.keys(parsedMessage)
-        );
+        console.log("centralHub test client got message: ", parsedMessage);
         // ignore state updates that are subsystem_stats
         if (
             !parsedMessage ||
@@ -163,10 +154,7 @@ export class CentralHubTestClient {
                     );
                 });
                 ws.addEventListener("close", (event) => {
-                    console.error(
-                        "centralHub test client socket closed",
-                        event
-                    );
+                    console.log("centralHub test client socket closed", event);
                 });
                 ws.addEventListener("message", this.handleHubMessage);
             } catch (error) {


### PR DESCRIPTION
This pull request includes changes to the `CentralHubTestClient` class and related test files to improve logging and simplify the code.

Improvements to logging:

* [`src/basic_bot/created_files/webapp/testHelpers/centralHub.ts`](diffhunk://#diff-f8974c0ff8105bdaf8ab315d3b5ed585ec29dba333eb23075cd6fdbf4fe71dc4L41-R44): Updated log messages in `startTestHub` to provide clearer information about the test thread.
* [`src/basic_bot/created_files/webapp/testHelpers/centralHub.ts`](diffhunk://#diff-f8974c0ff8105bdaf8ab315d3b5ed585ec29dba333eb23075cd6fdbf4fe71dc4L88-L93): Simplified logging in `nextMessageWaiter` by removing redundant logs.
* [`src/basic_bot/created_files/webapp/testHelpers/centralHub.ts`](diffhunk://#diff-f8974c0ff8105bdaf8ab315d3b5ed585ec29dba333eb23075cd6fdbf4fe71dc4L113-R108): Consolidated log message for received messages to be more concise.
* [`src/basic_bot/created_files/webapp/testHelpers/centralHub.ts`](diffhunk://#diff-f8974c0ff8105bdaf8ab315d3b5ed585ec29dba333eb23075cd6fdbf4fe71dc4L166-R157): Changed log level from `console.error` to `console.log` for socket close events to reduce noise.

Test configuration update:

* [`src/basic_bot/created_files/webapp/src/App.test.tsx`](diffhunk://#diff-ce827d25e2b25449d3f0e84522898a82dbd4daf0cc523cd5696e2b326777aa69L32-R32): Changed the `CentralHubTestClient` initialization string to a more descriptive name.