### PR TITLE
Star subscribers should receive updates to keys added after they subscribed

### DIFF
--- a/src/basic_bot/test_helpers/central_hub.py
+++ b/src/basic_bot/test_helpers/central_hub.py
@@ -78,5 +78,10 @@ def has_received_data(ws: websocket.WebSocket) -> Optional[Dict[str, Any]]:
 
 
 def has_received_state_update(ws: websocket.WebSocket, key: str, value: Any) -> bool:
-    stateUpdate = recv(ws)
-    return stateUpdate["type"] == "stateUpdate" and stateUpdate["data"][key] == value
+    while True:
+        message = recv(ws)
+        if message["type"] == "stateUpdate" and key in message["data"]:
+            break
+
+    stateUpdateData = message["data"]
+    return stateUpdateData.get(key) == value

--- a/tests/integration_tests/test_central_hub.py
+++ b/tests/integration_tests/test_central_hub.py
@@ -101,3 +101,24 @@ class TestCentralHub:
 
         ws1.close()
         ws2.close()
+
+    def test_subscribe_all(self):
+        ws1 = hub.connect("test_client_1")
+        hub.send_subscribe(ws1, "*")
+
+        ws2 = hub.connect("test_client_2")
+
+        # second client sends a known key (`set_angles`) update
+        hub.send_update_state(ws2, {"set_angles": TEST_ANGLES_1})
+
+        # first client should receive the set_angles update
+        assert hub.has_received_state_update(ws1, "set_angles", TEST_ANGLES_1)
+
+        # second client sends a completely new key (`foo`) update
+        hub.send_update_state(ws2, {"foo": "bar"})
+
+        # first client should receive the previously unknown key update
+        assert hub.has_received_state_update(ws1, "foo", "bar")
+
+        ws1.close()
+        ws2.close()


### PR DESCRIPTION

Subscribing to all keys via "*" key like,

```json
{
  "type": "subscribeState",
  "data": "*"
}
```

was previously only subscribing the client to the keys that existed in the state at the time of the subscription.   This PR fixes that issue and adds integration tests for subscribing to all keys.