### PR TITLE
Hub should stop sending to star subscribers

### DIFF
--- a/src/basic_bot/services/central_hub.py
+++ b/src/basic_bot/services/central_hub.py
@@ -254,6 +254,8 @@ async def unregister(websocket: WebSocketServerProtocol) -> None:
     )
     try:
         connected_sockets.remove(websocket)
+        star_subscribers.remove(websocket)
+
         for key in subscribers:
             subscribers[key].remove(websocket)
         subsystem_name = identities.pop(websocket, None)


### PR DESCRIPTION
After a star subscriber disconnects or is disconnected, central_hub should stop trying to relay state updates.  I caught this bug while testing D2 and noticed in the central_hub log that it was still trying to relay state updates to a closed browser client.  I'm not sure how to test for it from a harness point of view except maybe something like...

```
client-1: 
   connect
   subscribe * 
   disconnect 

client-2 
   connect
   send_update 
   ?  
```
maybe scan the log for an error?  client-1 will still not recieve anything if it reconnects, but the hub will still try.  I confirmed via manual test that this PR fixes the issue.