### PR TITLE
Add REST API to vision service to record video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # our stuff
 logs/
 pids/
+recorded_video/
 
 node_modules/
 package-lock.json

--- a/src/basic_bot/commons/constants.py
+++ b/src/basic_bot/commons/constants.py
@@ -214,6 +214,13 @@ BB_DISABLE_RECOGNITION_PROVIDER = env.env_bool("BB_DISABLE_RECOGNITION_PROVIDER"
     Set this to True to disable the recognition provider.
 """
 
+BB_VIDEO_PATH = env.env_string("BB_VIDEO_PATH", "./recorded_video")
+"""
+    default: "/dev/video0"
+
+    The path to the video device used by the camera.
+"""
+
 
 # # Logging all the env variables in test for debugging
 # if BB_ENV == "test":

--- a/src/basic_bot/commons/constants.py
+++ b/src/basic_bot/commons/constants.py
@@ -216,9 +216,9 @@ BB_DISABLE_RECOGNITION_PROVIDER = env.env_bool("BB_DISABLE_RECOGNITION_PROVIDER"
 
 BB_VIDEO_PATH = env.env_string("BB_VIDEO_PATH", "./recorded_video")
 """
-    default: "/dev/video0"
+    default: "./recorded_video"
 
-    The path to the video device used by the camera.
+    The path where the vision service saves recorded video.
 """
 
 

--- a/src/basic_bot/commons/cv2_utils.py
+++ b/src/basic_bot/commons/cv2_utils.py
@@ -1,0 +1,38 @@
+"""
+This module contains utility functions for working with OpenCV.
+"""
+
+import cv2
+import os
+import time
+
+
+from basic_bot.commons import constants as c, log
+from basic_bot.commons.camera_opencv import Camera
+
+
+def record_video(camera: Camera, seconds: float) -> str:
+    """
+    Record a video to BB_VIDEO_PATH for a specified number of seconds.
+    """
+    videoPath = os.path.realpath(c.BB_VIDEO_PATH)
+    os.makedirs(videoPath, exist_ok=True)
+
+    # Filename is the current date and time in the format `YYYYMMDD-HHMMSS.mp4`.
+    filename = os.path.join(videoPath, f"{time.strftime('%Y%m%d-%H%M%S')}.mp4")
+
+    fourcc = cv2.VideoWriter_fourcc(*"MJPG")  # type: ignore
+    writer = cv2.VideoWriter(
+        filename, fourcc, c.BB_CAMERA_FPS, (c.BB_VISION_WIDTH, c.BB_VISION_HEIGHT)
+    )
+
+    tstart = time.time()
+    log.info(f"Recording 10 seconds of video to {filename}")
+    while True:
+        if time.time() - tstart > seconds:
+            break
+        frame = camera.get_frame()
+        writer.write(frame)
+
+    writer.release()
+    return filename

--- a/src/basic_bot/commons/hub_state_monitor.py
+++ b/src/basic_bot/commons/hub_state_monitor.py
@@ -71,7 +71,12 @@ class HubStateMonitor:
             ]
         ] = None,
     ) -> None:
-        """Instantiate a HubStateMonitor object."""
+        """
+        Instantiate a HubStateMonitor object.
+
+        Note that subscribed_keys may be an empty list if you just want to
+        publish state updates to the central hub and not receive any state updates.
+        """
         self.hub_state = hub_state
         self.identity = identity
         self.subscribed_keys = subscribed_keys
@@ -106,8 +111,9 @@ class HubStateMonitor:
             state_keys = self.subscribed_keys if self.subscribed_keys != "*" else None
             self.connected_socket = websocket
             await messages.send_identity(websocket, self.identity)
-            await messages.send_subscribe(websocket, self.subscribed_keys)
-            await messages.send_get_state(websocket, state_keys)
+            if len(self.subscribed_keys) > 0:
+                await messages.send_subscribe(websocket, self.subscribed_keys)
+                await messages.send_get_state(websocket, state_keys)
             yield websocket
 
     async def parse_next_message(

--- a/src/basic_bot/services/vision.py
+++ b/src/basic_bot/services/vision.py
@@ -41,13 +41,18 @@ the numeric values of the bounding box in the image.
 ## Video Recording
 
 The video feed can be recorded using the `record_video` REST API.
-The video is recorded in the `recorded_video` subdirectory of
-project root directory.
+The video is recorded in the BB_VIDEO_PATH directory. Example:
 
-TODO: example rest API call to record video
+```sh
+curl http://localhost:5801/record_video
+```
+where
+- `localhost` is replaced by the IP address of the host running the vision service.
+- `5801` is the port the vision service is running on (default).  See `BB_VISION_PORT`
+in the configuration docs.
 
-Filename is the current date and time in the format `YYYYMMDD-HHMMSS.mp4`.
-The video is recorded in mp4 format.
+Filename of the saved file is the current date and time in the format
+`YYYYMMDD-HHMMSS.mp4`.
 
 ## Origin
 

--- a/src/basic_bot/services/vision.py
+++ b/src/basic_bot/services/vision.py
@@ -4,6 +4,8 @@ Provide image feed and object recognition based on open-cv for the
 video capture input.  This service will provide a list of objects
 and their bounding boxes in the image feed via central hub.
 
+## Video Feed
+
 A video feed is provided via http://<ip>:<port>/video_feed that
 can be used as the `src` attribute to an HTML 'img' element.
 The image feed is a multipart jpeg stream (for now; TODO: reassess this).
@@ -12,6 +14,7 @@ location, you can do something like:
 ```html
 <img src="http://localhost:5001/video_feed" />
 ```
+## Object Recognition
 
 The following data is provided to central_hub as fast as image capture and
 recognition can be done:
@@ -35,15 +38,28 @@ recognition can be done:
 The [x1, y1, x2, y2] bounding box above is actually sent as
 the numeric values of the bounding box in the image.
 
-Origin:
-    Some of this code was originally pilfered from
-    https://github.com/adeept/Adeept_RaspTank/blob/a6c45e8cc7df620ad8977845eda2b839647d5a83/server/app.py
+## Video Recording
 
-    Which looks like it was in turn pilfered from
-    https://blog.miguelgrinberg.com/post/flask-video-streaming-revisited
+The video feed can be recorded using the `record_video` REST API.
+The video is recorded in the `recorded_video` subdirectory of
+project root directory.
 
-    Thank you, @adeept and @miguelgrinberg!
+TODO: example rest API call to record video
+
+Filename is the current date and time in the format `YYYYMMDD-HHMMSS.mp4`.
+The video is recorded in mp4 format.
+
+## Origin
+
+Some of this code was originally pilfered from
+https://github.com/adeept/Adeept_RaspTank/blob/a6c45e8cc7df620ad8977845eda2b839647d5a83/server/app.py
+
+Which looks like it was in turn pilfered from
+https://blog.miguelgrinberg.com/post/flask-video-streaming-revisited
+
+Thank you, @adeept and @miguelgrinberg!
 """
+import asyncio
 import importlib
 import threading
 
@@ -53,10 +69,19 @@ from flask_cors import CORS
 
 import cv2
 
-from basic_bot.commons import constants as c, web_utils, log
+from basic_bot.commons import constants as c, web_utils, log, messages, cv2_utils
+
+from basic_bot.commons.hub_state import HubState
+from basic_bot.commons.hub_state_monitor import HubStateMonitor
 from basic_bot.commons.base_camera import BaseCamera
 from basic_bot.commons.recognition_provider import RecognitionProvider
 from typing import Generator
+
+# TODO : maybe using HubStateMonitor as just a means of publishing
+# state updates (without any actual monitoring) should be composed
+# into a separate class, like maybe HubStatePublisher.
+hub = HubStateMonitor(HubState({}), "vision", [])
+hub.start()
 
 # when running tests, assume we are headless and use the
 # mock camera which provides random images that should
@@ -111,7 +136,7 @@ def send_stats() -> Response:
     )
 
 
-@app.route("/pauseRecognition")
+@app.route("/pause_recognition")
 def pause_recognition() -> Response:
     """Use a GET request to pause the recognition provider."""
     if c.BB_DISABLE_RECOGNITION_PROVIDER:
@@ -121,13 +146,46 @@ def pause_recognition() -> Response:
     return web_utils.respond_ok(app)
 
 
-@app.route("/resumeRecognition")
+@app.route("/resume_recognition")
 def resume_recognition() -> Response:
     """Use a GET request to resume the recognition provider."""
     if c.BB_DISABLE_RECOGNITION_PROVIDER:
         return abort(404, "recognition provider disabled")
 
     recognition.resume()
+    return web_utils.respond_ok(app)
+
+
+is_recording = False
+
+
+@app.route("/record_video")
+def record_video() -> Response:
+    """Record the video feed to a file."""
+    global is_recording
+
+    if is_recording:
+        return web_utils.respond_not_ok(app, 304, "already recording")
+
+    is_recording = True
+    try:
+        asyncio.run(
+            messages.send_update_state(
+                hub.connected_socket, {"vision": {"recording": True}}
+            )
+        )
+        cv2_utils.record_video(camera, 10)
+    except Exception as e:
+        log.error(f"error recording video: {e}")
+        return web_utils.respond_not_ok(app, 500, f"error recording video")
+    finally:
+        is_recording = False
+        asyncio.run(
+            messages.send_update_state(
+                hub.connected_socket, {"vision": {"recording": False}}
+            )
+        )
+
     return web_utils.respond_ok(app)
 
 

--- a/src/basic_bot/services/vision.py
+++ b/src/basic_bot/services/vision.py
@@ -182,7 +182,7 @@ def record_video() -> Response:
         cv2_utils.record_video(camera, 10)
     except Exception as e:
         log.error(f"error recording video: {e}")
-        return web_utils.respond_not_ok(app, 500, f"error recording video")
+        return web_utils.respond_not_ok(app, 500, "error recording video")
     finally:
         is_recording = False
         asyncio.run(

--- a/tests/integration_tests/test_vision.py
+++ b/tests/integration_tests/test_vision.py
@@ -2,6 +2,7 @@
 import basic_bot.test_helpers.skip_unless_tflite_runtime  # noqa: F401
 
 import requests
+from pathlib import Path
 
 import basic_bot.test_helpers.central_hub as hub
 import basic_bot.test_helpers.start_stop as sst
@@ -105,3 +106,13 @@ class TestVisionCV2:
         detection is running at ~30fps!  That's kinda outstanding. Scatbot
         needed the Coral TPU to get to 28fps inference on the pi 4.
         """
+
+    def test_record_video(self):
+        file_count_before = len(list(Path(c.BB_VIDEO_PATH).glob("*.mp4")))
+        url = f"http://localhost:{c.BB_VISION_PORT}/record_video"
+        response = requests.get(url)
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "ok"
+        file_count_after = len(list(Path(c.BB_VIDEO_PATH).glob("*.mp4")))
+        assert file_count_after == file_count_before + 1

--- a/upload.sh
+++ b/upload.sh
@@ -36,6 +36,7 @@ rsync --progress --partial \
 --exclude=node_modules \
 --exclude=persisted_state.json \
 --exclude=logs/ \
+--exclude=recorded_video/ \
 --exclude=dist/ \
 --exclude=basic_bot.egg-info \
 --exclude=*.pid \


### PR DESCRIPTION
For MVP, record 10 seconds.    I'll add a URL argument later to specify the duration when needed.

This PR also: 
- adds ability to use HubStateMonitor for publish only.  See TODO in comment.
- 