### PR TITLE
Add thumbnail when saving video

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,12 +4,14 @@
 # the files that `bb_create` creates.
 
 
-# fail on any error
-set -e
-
+# this can fail on linux or if running on a machine without a node
+# installed
 echo "Installing npm dependencies locally..."
 cd src/basic_bot/created_files/webapp/ && npm install
 cd ../../../..
+
+# fail on any error
+set -e
 
 echo "Linting..."
 python -m flake8 src/basic_bot

--- a/src/basic_bot/commons/cv2_utils.py
+++ b/src/basic_bot/commons/cv2_utils.py
@@ -14,25 +14,41 @@ from basic_bot.commons.camera_opencv import Camera
 def record_video(camera: Camera, seconds: float) -> str:
     """
     Record a video to BB_VIDEO_PATH for a specified number of seconds.
+
+    Calling this function will save an MP4 video file to the BB_VIDEO_PATH directory.
+    The filename is the current date and time in the format `YYYYMMDD-HHMMSS.mp4`.
+
+    It will also save the first frame of the video as a JPEG image in the same directory
+    named `YYYYMMDD-HHMMSS.jpg`.
     """
     videoPath = os.path.realpath(c.BB_VIDEO_PATH)
     os.makedirs(videoPath, exist_ok=True)
 
-    # Filename is the current date and time in the format `YYYYMMDD-HHMMSS.mp4`.
-    filename = os.path.join(videoPath, f"{time.strftime('%Y%m%d-%H%M%S')}.mp4")
+    # Filenames are the current date and time in the format `YYYYMMDD-HHMMSS.mp4`.
+    base_file_name = time.strftime("%Y%m%d-%H%M%S")
+    video_filename = os.path.join(videoPath, f"{base_file_name}.mp4")
+    image_filename = os.path.join(videoPath, f"{base_file_name}.jpg")
 
     fourcc = cv2.VideoWriter_fourcc(*"MJPG")  # type: ignore
     writer = cv2.VideoWriter(
-        filename, fourcc, c.BB_CAMERA_FPS, (c.BB_VISION_WIDTH, c.BB_VISION_HEIGHT)
+        video_filename, fourcc, c.BB_CAMERA_FPS, (c.BB_VISION_WIDTH, c.BB_VISION_HEIGHT)
     )
+    first_frame = None
 
     tstart = time.time()
-    log.info(f"Recording 10 seconds of video to {filename}")
+    log.info(f"Recording 10 seconds of video to {video_filename}")
     while True:
         if time.time() - tstart > seconds:
             break
         frame = camera.get_frame()
-        writer.write(frame)
+        writer.write(frame)  # type: ignore
+        if first_frame is None:
+            first_frame = frame
 
     writer.release()
-    return filename
+
+    log.info(f"Saving thumbnail image to {image_filename}")
+    cv2.resize(first_frame, (int(c.BB_VISION_WIDTH / 3), int(c.BB_VISION_HEIGHT / 3)))  # type: ignore
+    cv2.imwrite(image_filename, first_frame)  # type: ignore
+
+    return base_file_name

--- a/tests/integration_tests/test_vision.py
+++ b/tests/integration_tests/test_vision.py
@@ -108,11 +108,21 @@ class TestVisionCV2:
         """
 
     def test_record_video(self):
-        file_count_before = len(list(Path(c.BB_VIDEO_PATH).glob("*.mp4")))
+        vidfile_count_before = len(list(Path(c.BB_VIDEO_PATH).glob("*.mp4")))
+        imgfile_count_before = len(list(Path(c.BB_VIDEO_PATH).glob("*.jpg")))
+
         url = f"http://localhost:{c.BB_VISION_PORT}/record_video"
         response = requests.get(url)
 
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
-        file_count_after = len(list(Path(c.BB_VIDEO_PATH).glob("*.mp4")))
-        assert file_count_after == file_count_before + 1
+
+        vidfile_count_after = len(list(Path(c.BB_VIDEO_PATH).glob("*.mp4")))
+        assert (
+            vidfile_count_after == vidfile_count_before + 1
+        ), "should have created exactly one video file"
+
+        imgfile_count_after = len(list(Path(c.BB_VIDEO_PATH).glob("*.jpg")))
+        assert (
+            imgfile_count_after == imgfile_count_before + 1
+        ), "should have created exactly one image file"


### PR DESCRIPTION
When video is recorded on request (earlier PR), also save a thumnail of the first frame for UI display.

Also, don't fail in build.sh when npm doesn't exist.  test_vision.sh itegration test does not run on MacOS due to lack of tensorflow lite support.  In order to run the vision itegration test, you either need to push a PR (does run on CI/CD) or preemptively, upload the code to linux machine - like the onboard Raspberry Pi and run the test there, which is what I did.

I also manually tested the .jpg image saved is visually correct.   You can use a simple GET request in a browser,  `wget` or `curl`  to `http://pi5.local:5801/record_video`
and then `scp` the recorded files locally.