### PR TITLE
record_video endpoint should accept optional duration url arg

### DIFF
--- a/sbin/vid_duration.py
+++ b/sbin/vid_duration.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import cv2
+import sys
+
+# Argv can be any video file path or URL accepted by OpenCV
+
+data = cv2.VideoCapture(sys.argv[1])
+
+# count the number of frames
+frames = data.get(cv2.CAP_PROP_FRAME_COUNT)
+fps = data.get(cv2.CAP_PROP_FPS)
+
+# calculate duration of the video
+seconds = frames / fps
+print(f"duration in seconds: {seconds}")

--- a/src/basic_bot/commons/vid_utils.py
+++ b/src/basic_bot/commons/vid_utils.py
@@ -12,7 +12,7 @@ from basic_bot.commons import constants as c, log
 from basic_bot.commons.camera_opencv import Camera
 
 
-def record_video(camera: Camera, seconds: float) -> str:
+def record_video(camera: Camera, duration: float) -> str:
     """
     Record a video to BB_VIDEO_PATH for a specified number of seconds.
 
@@ -39,9 +39,9 @@ def record_video(camera: Camera, seconds: float) -> str:
     first_frame = None
 
     tstart = time.time()
-    log.info(f"Recording 10 seconds of video to {video_filename}")
+    log.info(f"Recording {duration} seconds of video to {video_filename}")
     while True:
-        if time.time() - tstart > seconds:
+        if time.time() - tstart > duration:
             break
         frame = camera.get_frame()
         writer.write(frame)  # type: ignore

--- a/src/basic_bot/services/vision.py
+++ b/src/basic_bot/services/vision.py
@@ -77,7 +77,7 @@ import os
 import threading
 
 
-from flask import Flask, Response, abort, send_from_directory
+from flask import Flask, Response, abort, send_from_directory, request
 from flask_cors import CORS
 
 import cv2
@@ -179,15 +179,16 @@ def record_video() -> Response:
 
     if is_recording:
         return web_utils.respond_not_ok(app, 304, "already recording")
-
     is_recording = True
+
+    duration = float(request.args.get("duration", "10"))
     try:
         asyncio.run(
             messages.send_update_state(
                 hub.connected_socket, {"vision": {"recording": True}}
             )
         )
-        vid_utils.record_video(camera, 10)
+        vid_utils.record_video(camera, duration)
     except Exception as e:
         log.error(f"error recording video: {e}")
         return web_utils.respond_not_ok(app, 500, "error recording video")

--- a/src/basic_bot/test_helpers/camera_mock.py
+++ b/src/basic_bot/test_helpers/camera_mock.py
@@ -5,7 +5,7 @@ import time
 
 from typing import Generator
 
-from basic_bot.commons import log
+from basic_bot.commons import log, constants as c
 from basic_bot.commons.base_camera import BaseCamera
 
 log.info("Loaded basic_bot.test_helpers.camera_mock. loading images...")
@@ -52,6 +52,7 @@ class Camera(BaseCamera):
         """
         frame_count = 0
         while True:
+            tstart = time.time()
             frame_count += 1
             # for testing, half of the frames are pet images and half are not pet images
             if frame_count % 2 == 0:
@@ -62,4 +63,6 @@ class Camera(BaseCamera):
                 img = not_pet_images[index]
 
             yield img  # type: ignore
-            time.sleep(1 / 60)  # Limit supply to ~60 FPS
+            time.sleep(
+                1 / c.BB_CAMERA_FPS - (time.time() - tstart)
+            )  # Limit supply to camera FPS


### PR DESCRIPTION
This PR also makes the mock camera used during testing respect the BB_VISION_FPS config var and allows us to maybe tighten the constraint tolerance of the object detection integration test.  The CI/CD, if I recall, had the highest variance of pet/non-pet ratio for that test.

