### PR TITLE
 Video recording is asynchronous from API call

### DIFF
--- a/src/basic_bot/commons/constants.py
+++ b/src/basic_bot/commons/constants.py
@@ -19,69 +19,64 @@ import basic_bot.commons.env as env
 
 BB_ENV = env.env_string("BB_ENV", "development")
 """
-Default: "development"
-
-Test runner should set this to "test".
+Test runner will set this to "test".
 
 Set this to "production" on the onboard computer to run the bot in production
-mode.
+mode.  See [Getting Started Guide](https://littlebee.github.io/basic_bot/#add-bb_env-export)
+for more information.
 """
 
 BB_LOG_ALL_MESSAGES = env.env_bool("BB_LOG_ALL_MESSAGES", False)
 """
-    Default: False
-
-    Set this to True to log all messages sent and received by services to
-    each of their respective log files.
+Set this to True to log all messages sent and received by services to
+each of their respective log files.
 """
 
+BB_HUB_HOST = env.env_string("BB_HUB_HOST", "127.0.0.1")
+"""
+The websocket host that the central hub is running.
+"""
 
 BB_HUB_PORT = hub_port = env.env_int("BB_HUB_PORT", 5100)
 """
-    Default: 5100
-
-    This is the websocket port that the central hub listens on.
+The websocket port that the central_hub service listens on.
 """
-
 
 # Connect to central hub websocket
-BB_HUB_URI = f"ws://127.0.0.1:{BB_HUB_PORT}/ws"
+BB_HUB_URI = f"ws://{BB_HUB_HOST}:{BB_HUB_PORT}/ws"
 """
-    Default: `f"ws://127.0.0.1:{BB_HUB_PORT}/ws"`
-
+This is the full URI to connect to the central_hub service websocket.
 """
-
 
 # =============== Motor Control Service Constants
+
 BB_MOTOR_I2C_ADDRESS = env.env_int("BB_MOTOR_I2C_ADDRESS", 0x60)
 """
-    default: 0x60
-
-    Used by basic_bot.services.motor_control_2w to connect to the
-    i2c motor controller.
+Used by basic_bot.services.motor_control_2w to connect to the i2c
+motor controller.
 """
+
 BB_LEFT_MOTOR_CHANNEL = env.env_int("BB_LEFT_MOTOR_CHANNEL", 1)
 """
-    default: 1
+default: 1
 """
+
 BB_RIGHT_MOTOR_CHANNEL = env.env_int("BB_RIGHT_MOTOR_CHANNEL", 2)
 """
-    default: 2
+default: 2
 """
 
 # =============== Servo Service Constants
 BB_SERVO_CONFIG_FILE = env.env_string("BB_SERVO_CONFIG_FILE", "./servo_config.yml")
 """
-    See api docs for servo control services
+See api docs for servo control services
 """
 
 # =============== System Stats Service Constants
 BB_SYSTEM_STATS_SAMPLE_INTERVAL = env.env_float("BB_SYSTEM_STATS_SAMPLE_INTERVAL", 1)
 """
-    In seconds, the interval at which the system stats service samples the system
-    and publishes system stats to the central hub.
-
-    default: 1
+In seconds, the interval at which the system stats service samples the system
+and publishes system stats to the central hub.
 """
 
 
@@ -95,81 +90,63 @@ default_camera_module = (
 # for example, `BB_CAMERA_MODULE=basic_bot.commons.camera_picamera`
 BB_CAMERA_MODULE = env.env_string("BB_CAMERA_MODULE", default_camera_module)
 """
-    default: "basic_bot.commons.camera_opencv" or
-        "basic_bot.test_helpers.camera_mock" when BB_ENV=test
+default: "basic_bot.commons.camera_opencv" or
+"basic_bot.test_helpers.camera_mock" when BB_ENV=test
 
-    When using a ribbon cable camera on a Raspberry Pi 4/5, set this to
-    "basic_bot.commons.camera_picamera".
+When using a ribbon cable camera on a Raspberry Pi 4/5, set this to
+"basic_bot.commons.camera_picamera".
 """
 
 BB_CAMERA_CHANNEL = env.env_int("BB_CAMERA_CHANNEL", 0)
 """
-    default: 0
-
-    This is the camera channel to use. 0 is the default camera.
+The camera channel to use. 0 is the default camera.
 """
 
 BB_CAMERA_ROTATION = env.env_int("BB_CAMERA_ROTATION", 0)
 """
-    default: 0
-
-    This is the camera rotation in degrees. 0 is the default rotation.
+The camera rotation in degrees. 0 is the default rotation.
 """
 
 BB_CAMERA_FPS = env.env_int("BB_CAMERA_FPS", 30)
 """
-    default: 30
-
-    This is the camera setting frames per second.
+The camera setting frames per second.
 """
 
 BB_VISION_WIDTH = env.env_int("BB_VISION_WIDTH", 640)
 """
-    default: 640
-
-    In pixels, this is the width of the camera frame to capture.
+In pixels, this is the width of the camera frame to capture.
 """
 
 BB_VISION_HEIGHT = env.env_int("BB_VISION_HEIGHT", 480)
 """
-    default: 480
-
-    In pixels, this is the height of the camera frame to capture.
+In pixels, this is the height of the camera frame to capture.
 
 """
 
 BB_VISION_FOV = 62
 """
-    default: 62
-
-    This is the field of view of the camera in degrees.
-    Depends on camera; RPi v2 cam is 62deg.
+The field of view of the camera in degrees.  Depends on camera;
+RPi v2 cam is 62 deg.
 """
 
 BB_OBJECT_DETECTION_THRESHOLD = env.env_float("BB_OBJECT_DETECTION_THRESHOLD", 0.5)
 """
-    default: 0.5
-
-    This is the object detection threshold percentage 0 - 1; higher = greater confidence.
+The object detection threshold percentage 0 - 1; higher = greater confidence.
 """
 
 # to enable the Coral USB TPU, you must use the tflite_detector and set this to True
 BB_ENABLE_CORAL_TPU = env.env_bool("BB_ENABLE_CORAL_TPU", False)
 """
-    default: False
-
-    Set this to True to enable the Coral USB TPU for object detection.
+Set this to True to enable the Coral USB TPU for object detection.
 """
 
 BB_TFLITE_MODEL = env.env_string(
     "BB_TFLITE_MODEL", "./models/tflite/ssd_mobilenet_v1_coco_quant_postprocess.tflite"
 )
 """
-    default: "./models/tflite/ssd_mobilenet_v1_coco_quant_postprocess.tflite"
-
-    Which model to use for object detection when BB_ENABLE_CORAL_TPU is false.
-    Default is the model from the coral site which is faster than the model
-    from the tensorflow hub
+Which model to use for object detection when BB_ENABLE_CORAL_TPU is false.
+Default is the model from the coral site which is faster than the model
+from the tensorflow hub
 """
 
 BB_TFLITE_MODEL_CORAL = env.env_string(
@@ -177,53 +154,46 @@ BB_TFLITE_MODEL_CORAL = env.env_string(
     "./models/tflite/ssd_mobilenet_v1_coco_quant_postprocess_edgetpu.tflite",
 )
 """
-    default: "./models/tflite/ssd_mobilenet_v1_coco_quant_postprocess_edgetpu.tflite"
-
-    Which model to use for object detection when BB_ENABLE_CORAL_TPU is true.
+Which model to use for object detection when BB_ENABLE_CORAL_TPU is true.
 """
 
 # number of threads to use for tflite detection
 BB_TFLITE_THREADS = env.env_int("BB_TFLITE_THREADS", 3)
 """
-    default: 3
+Number of threads to use for tflite detection.  Testing object detection
+on a Rasberry PI 5, without any other CPU or memory pressure, 4 tflite threads
+was only 1 fps faster (29.5fps) than 3 threads (28.6fps).  2 threads was 22fps.
 
-    Number of threads to use for tflite detection.  Testing object detection
-    on a Rasberry PI 5, without any other CPU or memory pressure, 4 tflite threads
-    was only 1 fps faster (29.5fps) than 3 threads (28.6fps).  2 threads was 22fps.
-
-    Warning: Setting this too high can actually reduce the object detection  frame rate.
-    In the case of daphbot_due, which has a [pygame based onboard UI service](https://github.com/littlebee/daphbot-due/blob/main/src/onboard_ui_service.py)
-    that has a configurable render frame rate, the tflite detection running on 4 threads
-    was reduced to about 12 fps when the render frame rate was set to 30fps.
+Warning: Setting this too high can actually reduce the object detection  frame rate.
+In the case of daphbot_due, which has a [pygame based onboard UI service](https://github.com/littlebee/daphbot-due/blob/main/src/onboard_ui_service.py)
+that has a configurable render frame rate, the tflite detection running on 4 threads
+was reduced to about 12 fps when the render frame rate was set to 30fps.
 """
 
-# http port used by the vision service for video streaming
-port = 5802 if BB_ENV == "test" else 5801
-BB_VISION_PORT = env.env_int("BB_VISION_PORT", port)
+BB_VISION_HOST = env.env_string("BB_VISION_HOST", "127.0.0.1")
 """
-    default: 5802 when BB_ENV=test; 5801 otherwise
+The IP address that the vision service is running on for REST api and video streaming.
+"""
 
-    This is the HTTP port that the vision service listens  on for video
-    streaming and REST api.
+BB_VISION_PORT = env.env_int("BB_VISION_PORT", 5802 if BB_ENV == "test" else 5801)
 """
+The HTTP port that the vision service listens on for video streaming and REST api.
+"""
+
+BB_VISION_URI = env.env_string(
+    "BB_VISION_URI", f"http://{BB_VISION_HOST}:{BB_VISION_PORT}"
+)
+"""
+The full URI to connect to the vision service REST and video streaming.
+"""
+
 
 BB_DISABLE_RECOGNITION_PROVIDER = env.env_bool("BB_DISABLE_RECOGNITION_PROVIDER", False)
 """
-    default: False
-
-    Set this to True to disable the recognition provider.
+Set this to True to disable the recognition provider.
 """
 
 BB_VIDEO_PATH = env.env_string("BB_VIDEO_PATH", "./recorded_video")
 """
-    default: "./recorded_video"
-
-    The path where the vision service saves recorded video.
+The path where the vision service saves recorded video.
 """
-
-
-# # Logging all the env variables in test for debugging
-# if BB_ENV == "test":
-#     print("Environment variables:")
-#     for name, value in os.environ.items():
-#         print("{0}: {1}".format(name, value))

--- a/src/basic_bot/commons/vid_utils.py
+++ b/src/basic_bot/commons/vid_utils.py
@@ -11,6 +11,9 @@ import time
 from basic_bot.commons import constants as c, log
 from basic_bot.commons.camera_opencv import Camera
 
+THUMBNAIL_WIDTH = 80
+THUMBNAIL_HEIGHT = 60
+
 
 def record_video(camera: Camera, duration: float) -> str:
     """
@@ -27,7 +30,7 @@ def record_video(camera: Camera, duration: float) -> str:
 
     # Filenames are the current date and time in the format `YYYYMMDD-HHMMSS.mp4`.
     base_file_name = time.strftime("%Y%m%d-%H%M%S")
-    raw_filename = os.path.join(videoPath, "latest_raw.mp4")
+    raw_filename = os.path.join(videoPath, f"{base_file_name}_raw.mp4")
     video_filename = os.path.join(videoPath, f"{base_file_name}.mp4")
     image_filename = os.path.join(videoPath, f"{base_file_name}.jpg")
 
@@ -53,7 +56,7 @@ def record_video(camera: Camera, duration: float) -> str:
     convert_video_to_h264(raw_filename, video_filename)
 
     log.info(f"Saving thumbnail image to {image_filename}")
-    cv2.resize(first_frame, (int(c.BB_VISION_WIDTH / 3), int(c.BB_VISION_HEIGHT / 3)))  # type: ignore
+    cv2.resize(first_frame, (THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT))  # type: ignore
     cv2.imwrite(image_filename, first_frame)  # type: ignore
 
     return base_file_name

--- a/src/basic_bot/commons/vision_client.py
+++ b/src/basic_bot/commons/vision_client.py
@@ -1,0 +1,51 @@
+"""
+Utility functions for interacting with the vision service REST_API.
+"""
+
+import requests
+
+from basic_bot.commons import log, constants as c
+
+
+def send_record_video_request(duration: float) -> requests.Response:
+    """
+    Send a request to the vision service to start recording video.
+    """
+    if c.BB_LOG_ALL_MESSAGES:
+        log.info(f"Sending record video request for {duration} seconds")
+    response = requests.get(
+        f"{c.BB_VISION_URI}/record_video",
+        params={"duration": duration},
+    )
+    response.raise_for_status()
+    return response
+
+
+def fetch_recorded_videos() -> requests.Response:
+    """
+    Send a request to the vision service to retrieve a list of recorded videos.
+
+    The resonse.json() will be a list of strings, each string is a base filename
+    that can be appended with ".mp4" or ".jpg" to get the video or thumbnail image.
+    """
+    if c.BB_LOG_ALL_MESSAGES:
+        log.info(f"Sending recorded_video request to {c.BB_VISION_URI}")
+    response = requests.get(f"{c.BB_VISION_URI}/recorded_video")
+    response.raise_for_status()
+    return response
+
+
+def fetch_recorded_video(file_name: str) -> requests.Response:
+    """
+    Send a request to the vision service to retrieve a list of recorded videos.
+
+    The file_name should be appended with ".mp4" or ".jpg" to get the video or
+    thumbnail image.
+    """
+    if c.BB_LOG_ALL_MESSAGES:
+        log.info(f"Sending record video request for {file_name}")
+    response = requests.get(
+        f"{c.BB_VISION_URI}/recorded_video/{file_name}",
+    )
+    response.raise_for_status()
+    return response

--- a/tests/integration_tests/test_vision.py
+++ b/tests/integration_tests/test_vision.py
@@ -3,6 +3,7 @@ import basic_bot.test_helpers.skip_unless_tflite_runtime  # noqa: F401
 
 import cv2
 import requests
+import time
 from pathlib import Path
 
 import basic_bot.test_helpers.central_hub as hub
@@ -121,6 +122,10 @@ class TestVisionCV2:
         response = vision_client.send_record_video_request(TEST_DURATION)
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
+
+        # The video recording is started async. Recording, reencoding the video,
+        # and generating the thumbnail (mostly reencoding) takes a few seconds
+        time.sleep(TEST_DURATION * 2)
 
         vidfile_count_after = len(list(Path(c.BB_VIDEO_PATH).glob("*.mp4")))
         assert (

--- a/tests/integration_tests/test_vision.py
+++ b/tests/integration_tests/test_vision.py
@@ -123,6 +123,11 @@ class TestVisionCV2:
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
 
+        # Test that the service will only record one video at a time and return
+        # not ok if a second request is made while the first is still recording
+        response = vision_client.send_record_video_request(TEST_DURATION)
+        assert response.json()["status"] == 304
+
         # The video recording is started async. Recording, reencoding the video,
         # and generating the thumbnail (mostly reencoding) takes a few seconds
         time.sleep(TEST_DURATION * 2)


### PR DESCRIPTION
The record_video vision service API should start capturing frames and immediately return.  The recording and processing of the video (reencoding + thumbnail) should happen in the background and the recorded video segments should be near contiguous.

Also:

- reduce the thumbnail size to 80x60.
- Adds `basic_bot.commons.vision_client` for services or other python code to send requests and get the responses.
- Updates the test_vision.py integration test to use the vision_client thereby testing it as well
- Also cleans up basic_bot.commons.constants.py doc strings.  No need for default since the whole file is shown in the docs.
- Adds more finite vision config for API host, URI and port