### PR TITLE
Add a large thumbnail (320x240) in addition to small (80x60) with recorded video

### DIFF
--- a/src/basic_bot/commons/vid_utils.py
+++ b/src/basic_bot/commons/vid_utils.py
@@ -13,6 +13,8 @@ from basic_bot.commons.camera_opencv import Camera
 
 THUMBNAIL_WIDTH = 80
 THUMBNAIL_HEIGHT = 60
+LG_THUMBNAIL_WIDTH = 320
+LG_THUMBNAIL_HEIGHT = 240
 
 
 def record_video(camera: Camera, duration: float) -> str:
@@ -33,6 +35,7 @@ def record_video(camera: Camera, duration: float) -> str:
     raw_filename = os.path.join(videoPath, f"{base_file_name}_raw.mp4")
     video_filename = os.path.join(videoPath, f"{base_file_name}.mp4")
     image_filename = os.path.join(videoPath, f"{base_file_name}.jpg")
+    lg_image_filename = os.path.join(videoPath, f"{base_file_name}_lg.jpg")
 
     # fourcc = cv2.VideoWriter_fourcc(*"avc1")  # type: ignore
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # type: ignore
@@ -56,8 +59,12 @@ def record_video(camera: Camera, duration: float) -> str:
     convert_video_to_h264(raw_filename, video_filename)
 
     log.info(f"Saving thumbnail image to {image_filename}")
-    cv2.resize(first_frame, (THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT))  # type: ignore
-    cv2.imwrite(image_filename, first_frame)  # type: ignore
+    resized_frame = cv2.resize(first_frame, (THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT))  # type: ignore
+    cv2.imwrite(image_filename, resized_frame)
+
+    log.info(f"Saving thumbnail image to {lg_image_filename}")
+    resized_frame = cv2.resize(first_frame, (LG_THUMBNAIL_WIDTH, LG_THUMBNAIL_HEIGHT))  # type: ignore
+    cv2.imwrite(lg_image_filename, resized_frame)
 
     return base_file_name
 

--- a/tests/integration_tests/test_vision.py
+++ b/tests/integration_tests/test_vision.py
@@ -139,8 +139,8 @@ class TestVisionCV2:
 
         imgfile_count_after = len(list(Path(c.BB_VIDEO_PATH).glob("*.jpg")))
         assert (
-            imgfile_count_after == imgfile_count_before + 1
-        ), "should have created exactly one image file"
+            imgfile_count_after == imgfile_count_before + 2
+        ), "should have created exactly two .jpg files"
 
         # tests video list retrieval
         response = vision_client.fetch_recorded_videos()

--- a/tests/integration_tests/test_vision.py
+++ b/tests/integration_tests/test_vision.py
@@ -24,7 +24,7 @@ def teardown_module():
     sst.stop_service("vision")
 
 
-class TestVisionCV2:
+class TestVision:
     def test_object_detection(self):
         ws = hub.connect()
         # this name shows up in central hub logs and is helpful for debugging
@@ -129,8 +129,8 @@ class TestVisionCV2:
         assert response.json()["status"] == 304
 
         # The video recording is started async. Recording, reencoding the video,
-        # and generating the thumbnail (mostly reencoding) takes a few seconds
-        time.sleep(TEST_DURATION * 2)
+        # and generating the thumbnails (mostly reencoding) takes a few seconds
+        time.sleep(TEST_DURATION * 3)
 
         vidfile_count_after = len(list(Path(c.BB_VIDEO_PATH).glob("*.mp4")))
         assert (


### PR DESCRIPTION
The UI that I'm building for recorded videos will need the tiny thumbnail (80x60) for a timeline and also need a larger (320x240) image for popups.
 
This also fixes an issue where we were saving the full-frame image size (640x480) image instead of the resized