### PR TITLE
Add BB_WEB_PUBLIC environment variable for configurable web assets path

### DIFF
--- a/src/basic_bot/commons/constants.py
+++ b/src/basic_bot/commons/constants.py
@@ -204,3 +204,10 @@ BB_VIDEO_PATH = env.env_string("BB_VIDEO_PATH", "./recorded_video")
 """
 The path where the vision service saves recorded video.
 """
+
+# =============== Web Server Constants
+BB_WEB_PUBLIC = env.env_string("BB_WEB_PUBLIC", "./webapp/dist")
+"""
+The path to the directory containing the web application's static files.
+The web server will serve files from this directory.
+"""

--- a/src/basic_bot/services/web_server.py
+++ b/src/basic_bot/services/web_server.py
@@ -14,7 +14,7 @@ import psutil
 from flask import Flask, send_from_directory
 from flask_cors import CORS
 
-from basic_bot.commons import web_utils, log
+from basic_bot.commons import web_utils, log, constants as c
 from basic_bot.commons.hub_state import HubState
 from basic_bot.commons.hub_state_monitor import HubStateMonitor
 
@@ -26,7 +26,7 @@ CORS(app, supports_credentials=True)
 monitor = HubStateMonitor(hub_state, "webserver", "*")
 monitor.start()
 
-dir_path = os.path.join(os.getcwd(), "webapp/dist")
+dir_path = os.path.join(os.getcwd(), c.BB_WEB_PUBLIC)
 log.info(f"serving from dir_path: {dir_path}")
 
 


### PR DESCRIPTION
## Summary
- Replace hard-coded webapp/dist path in web_server.py with configurable BB_WEB_PUBLIC environment variable
- Add BB_WEB_PUBLIC constant to commons/constants.py with default "./webapp/dist"
- Maintain backward compatibility with existing deployments

## Test plan
- [x] Build passes with linting and type checking
- [x] Default behavior unchanged (serves from ./webapp/dist)
- [x] Environment variable override works correctly
- [x] Import structure follows project conventions

🤖 Generated with [Claude Code](https://claude.ai/code)