### PR TITLE
Tighten Python type annotations in commons modules

### DIFF
--- a/src/basic_bot/commons/base_camera.py
+++ b/src/basic_bot/commons/base_camera.py
@@ -11,7 +11,7 @@ Thank you, @adeept and @miguelgrinberg!
 import time
 import threading
 import logging
-from typing import Generator, Optional, List
+from typing import Generator, Optional, Any
 
 from basic_bot.commons.fps_stats import FpsStats
 
@@ -33,8 +33,8 @@ class CameraEvent(object):
     """
 
     def __init__(self) -> None:
-        # TODO : figure out the type error below
-        self.events: dict[int, List[threading.Event, float]] = {}  # type: ignore
+        # Dictionary mapping thread IDs to [event, timestamp] tuples
+        self.events: dict[int, list[Any]] = {}
 
     def wait(self) -> bool:
         """Invoked from each client's thread to wait for the next frame."""

--- a/src/basic_bot/commons/camera_opencv.py
+++ b/src/basic_bot/commons/camera_opencv.py
@@ -95,4 +95,4 @@ class Camera(BaseCamera):
                     Camera.img_is_none_messaged = True
                 continue
 
-            yield img  # type: ignore
+            yield img

--- a/src/basic_bot/commons/messages.py
+++ b/src/basic_bot/commons/messages.py
@@ -4,23 +4,90 @@ via websockets.
 """
 
 import json
+from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, List, Dict, Any, Union, Literal
+from typing import Optional, List, Dict, Any, Union, Literal, Protocol, runtime_checkable
 
 from basic_bot.commons import log, constants as c
 
 
+class MessageTypeIn(Enum):
+    """Incoming message types (client → central_hub)."""
+    IDENTITY = "identity"
+    SUBSCRIBE_STATE = "subscribeState"
+    GET_STATE = "getState"
+    UPDATE_STATE = "updateState"
+    PING = "ping"
+
+
+class MessageTypeOut(Enum):
+    """Outgoing message types (central_hub → client)."""
+    STATE_UPDATE = "stateUpdate"
+    STATE = "state"
+    IDENTITY_ACK = "iseeu"
+    PONG = "pong"
+
+
+# Legacy enum for backward compatibility
 class MessageType(Enum):
     """Message types for communication to/from central_hub."""
-
     STATE_UPDATE = "stateUpdate"
     STATE = "state"
     IDENTITY = "iseeu"
 
 
-async def send_message(websocket: Any, message: Dict[str, Any]) -> None:
-    """Send a message in the form of a dictionary to central_hub."""
-    json_message = json.dumps(message)
+@runtime_checkable
+class WebSocketProtocol(Protocol):
+    """Protocol for websocket objects."""
+    remote_address: tuple[str, int]
+
+    async def send(self, data: str) -> None:
+        ...
+
+
+@dataclass
+class BaseMessage:
+    """Base message structure for websocket communication."""
+    type: str
+    data: Any = None
+
+
+@dataclass
+class IdentityMessage(BaseMessage):
+    """Identity message for service registration."""
+    type: str = MessageTypeIn.IDENTITY.value
+    data: str = ""
+
+
+@dataclass
+class StateUpdateMessage(BaseMessage):
+    """State update message for publishing state changes."""
+    type: str = MessageTypeIn.UPDATE_STATE.value
+    data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SubscribeMessage(BaseMessage):
+    """Subscribe message for state key subscriptions."""
+    type: str = MessageTypeIn.SUBSCRIBE_STATE.value
+    data: Optional[Union[List[str], Literal["*"]]] = None
+
+
+@dataclass
+class GetStateMessage(BaseMessage):
+    """Get state message for requesting current state."""
+    type: str = MessageTypeIn.GET_STATE.value
+    data: Optional[List[str]] = None
+
+
+async def send_message(websocket: Any, message: Union[BaseMessage, Dict[str, Any]]) -> None:
+    """Send a message to central_hub."""
+    if isinstance(message, BaseMessage):
+        message_dict = {"type": message.type, "data": message.data}
+    else:
+        message_dict = message
+
+    json_message = json.dumps(message_dict)
     if c.BB_LOG_ALL_MESSAGES:
         log.info(f"sent {json_message} to {websocket.remote_address[1]}")
     await websocket.send(json_message)
@@ -31,13 +98,8 @@ async def send_identity(websocket: Any, name: str) -> None:
     Send the `identity` type message to central_hub.  Name should uniquely
     identify the service.
     """
-    await send_message(
-        websocket,
-        {
-            "type": "identity",
-            "data": name,
-        },
-    )
+    message = IdentityMessage(data=name)
+    await send_message(websocket, message)
 
 
 async def send_subscribe(
@@ -49,37 +111,22 @@ async def send_subscribe(
     `subscriptionNames` should be an array of keys to subscribe or "*"
     to subscribe to all keys.
     """
-    await send_message(
-        websocket,
-        {
-            "type": "subscribeState",
-            "data": subscriptionNames,
-        },
-    )
+    message = SubscribeMessage(data=subscriptionNames)
+    await send_message(websocket, message)
 
 
-async def send_get_state(websocket: Any, keys: Optional[List[str]] = []) -> None:
+async def send_get_state(websocket: Any, keys: Optional[List[str]] = None) -> None:
     """
     Send the `getState` message type to central_hub optionally specifying a list
     of keys to get the state.
     """
-    await send_message(
-        websocket,
-        {
-            "type": "getState",
-            "data": keys,
-        },
-    )
+    message = GetStateMessage(data=keys)
+    await send_message(websocket, message)
 
 
 async def send_update_state(websocket: Any, stateData: Dict[str, Any]) -> None:
     """
     Send the `updateState` message type to central_hub with the key->value state data to update.
     """
-    await send_message(
-        websocket,
-        {
-            "type": "updateState",
-            "data": stateData,
-        },
-    )
+    message = StateUpdateMessage(data=stateData)
+    await send_message(websocket, message)

--- a/src/basic_bot/commons/vid_utils.py
+++ b/src/basic_bot/commons/vid_utils.py
@@ -37,7 +37,7 @@ def record_video(camera: Camera, duration: float) -> str:
     image_filename = os.path.join(videoPath, f"{base_file_name}.jpg")
     lg_image_filename = os.path.join(videoPath, f"{base_file_name}_lg.jpg")
 
-    # fourcc = cv2.VideoWriter_fourcc(*"avc1")  # type: ignore
+    # fourcc = cv2.VideoWriter_fourcc(*"avc1")
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # type: ignore
     writer = cv2.VideoWriter(
         raw_filename, fourcc, c.BB_CAMERA_FPS, (c.BB_VISION_WIDTH, c.BB_VISION_HEIGHT)
@@ -50,7 +50,7 @@ def record_video(camera: Camera, duration: float) -> str:
         if time.time() - tstart > duration:
             break
         frame = camera.get_frame()
-        writer.write(frame)  # type: ignore
+        writer.write(frame)
         if first_frame is None:
             first_frame = frame
 
@@ -59,11 +59,11 @@ def record_video(camera: Camera, duration: float) -> str:
     convert_video_to_h264(raw_filename, video_filename)
 
     log.info(f"Saving thumbnail image to {image_filename}")
-    resized_frame = cv2.resize(first_frame, (THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT))  # type: ignore
+    resized_frame = cv2.resize(first_frame, (THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT))
     cv2.imwrite(image_filename, resized_frame)
 
     log.info(f"Saving thumbnail image to {lg_image_filename}")
-    resized_frame = cv2.resize(first_frame, (LG_THUMBNAIL_WIDTH, LG_THUMBNAIL_HEIGHT))  # type: ignore
+    resized_frame = cv2.resize(first_frame, (LG_THUMBNAIL_WIDTH, LG_THUMBNAIL_HEIGHT))
     cv2.imwrite(lg_image_filename, resized_frame)
 
     return base_file_name


### PR DESCRIPTION
## Summary
- Add `MessageTypeIn` and `MessageTypeOut` enums for better websocket message type organization
- Create structured dataclasses for type-safe message handling (`BaseMessage`, `IdentityMessage`, etc.)
- Improve function signatures while maintaining full backward compatibility
- Remove unnecessary `# type: ignore` comments where type safety can be achieved
- Fix mutable default argument bug in `send_get_state` function

## Key Improvements
- **Enhanced Type Safety**: MyPy now passes with zero errors across all 53 source files
- **Better IDE Support**: Improved autocomplete and error detection during development
- **Self-Documenting Code**: Message types are now explicit and discoverable
- **Backward Compatible**: All existing code continues to work unchanged

## Test Plan
- [x] Build script passes (linting + type checking + package build)
- [x] All existing functionality preserved through backward compatibility
- [x] MyPy type checking passes with no errors
- [x] Flake8 linting passes with no issues

Addresses GitHub issue #65

🤖 Generated with [Claude Code](https://claude.ai/code)