### PR TITLE
Strict mypy and ensure cross-platform consistency

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,26 @@
 [mypy]
-ignore_missing_imports = True
+ignore_missing_imports = False
+strict = False
+warn_return_any = False
+warn_unused_configs = True
+disallow_untyped_defs = False
 exclude = node_modules
+
+# Enable strict checking only for specific modules to catch OpenCV type issues
+[mypy-basic_bot.commons.camera_opencv]
+strict = True
+no_strict_optional = True
+
+[mypy-basic_bot.commons.vid_utils]
+strict = True
+no_strict_optional = True
+
+# Specific modules where we need to ignore missing imports
+[mypy-cv2.*]
+ignore_missing_imports = True
+
+[mypy-tflite_runtime.*]
+ignore_missing_imports = True
+
+[mypy-picamera2.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,3 +23,10 @@ ignore_missing_imports = True
 
 [mypy-picamera2.*]
 ignore_missing_imports = True
+
+# AI/ML optional dependencies (may not be available in all environments)
+[mypy-ai_edge_litert.*]
+ignore_missing_imports = True
+
+[mypy-libcamera.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,22 +1,21 @@
 [mypy]
+# Ensure consistent behavior across platforms
+python_version = 3.9
+platform = linux
 ignore_missing_imports = False
 strict = False
 warn_return_any = False
 warn_unused_configs = True
 disallow_untyped_defs = False
 exclude = node_modules
+# Force consistent stub resolution
+no_site_packages = False
 
-# Enable strict checking only for specific modules to catch OpenCV type issues
-[mypy-basic_bot.commons.camera_opencv]
-strict = True
-no_strict_optional = True
+# Specific modules where we need to ignore missing imports for all platforms
+[mypy-psutil]
+ignore_missing_imports = True
 
-[mypy-basic_bot.commons.vid_utils]
-strict = True
-no_strict_optional = True
-
-# Specific modules where we need to ignore missing imports
-[mypy-cv2.*]
+[mypy-psutil.*]
 ignore_missing_imports = True
 
 [mypy-tflite_runtime.*]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,12 @@ types-requests
 types-PyYAML
 types-jsonschema
 opencv-stubs
+
+# Runtime dependencies needed for mypy type checking
+numpy
+websockets
+websocket-client
+aiohttp
+Pillow
+aiortc
+av

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ opencv-stubs
 
 # Runtime dependencies needed for mypy type checking
 numpy
-websockets
+websockets==10.4
 websocket-client
 aiohttp
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ types-Flask-Cors
 types-psutil
 types-requests
 types-PyYAML
+types-jsonschema
+opencv-stubs

--- a/src/basic_bot/bb_killall.py
+++ b/src/basic_bot/bb_killall.py
@@ -22,11 +22,11 @@ import psutil
 import signal
 
 
-def main():
+def main() -> None:
     matching_processes = []
     for process in psutil.process_iter(["pid", "name", "cmdline"]):
         try:
-            cmdLine = str(process.info.get("cmdline"))
+            cmdLine = str(process.info.get("cmdline"))  # type: ignore[attr-defined]
             if cmdLine:
                 # print("looking at: ", cmdLine)
                 if "via=bb_start" in cmdLine:

--- a/src/basic_bot/bb_ps.py
+++ b/src/basic_bot/bb_ps.py
@@ -16,11 +16,11 @@ bb_ps
 import psutil
 
 
-def main():
+def main() -> None:
     matching_processes = []
     for process in psutil.process_iter(["pid", "name", "cmdline"]):
         try:
-            cmdLine = str(process.info.get("cmdline"))
+            cmdLine = str(process.info.get("cmdline"))  # type: ignore[attr-defined]
             if cmdLine:
                 # print("looking at: ", cmdLine)
                 if "via=bb_start" in cmdLine:

--- a/src/basic_bot/bb_start.py
+++ b/src/basic_bot/bb_start.py
@@ -31,7 +31,7 @@ import yaml
 from jsonschema import validate, ValidationError
 
 
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, Any
 
 
 from basic_bot.commons.script_helpers.pid_files import is_pid_file_valid
@@ -55,7 +55,7 @@ arg_parser.add_argument(
 )
 
 
-def validate_unique_names(config):
+def validate_unique_names(config: dict[str, Any]) -> bool:
     service_names = []
     for service in config["services"]:
         service_name = service["name"]
@@ -138,7 +138,7 @@ def start_service(
             )
 
 
-def start_services(config: dict, services_filter: Optional[List[str]] = None):
+def start_services(config: dict[str, Any], services_filter: Optional[List[str]] = None) -> None:
     env_vars = config.get("env", {})
     env_vars.update(config.get(f"{c.BB_ENV}_env", {}))
 

--- a/src/basic_bot/bb_stop.py
+++ b/src/basic_bot/bb_stop.py
@@ -18,7 +18,7 @@ import signal
 import yaml
 from jsonschema import validate, ValidationError
 
-from typing import Optional, List
+from typing import Optional, List, Any
 
 
 from basic_bot.commons.script_helpers.pid_files import is_pid_file_valid
@@ -79,7 +79,7 @@ def stop_service(
     os.remove(pid_file)
 
 
-def stop_services(config: dict, services_filter: Optional[List[str]] = None) -> None:
+def stop_services(config: dict[str, Any], services_filter: Optional[List[str]] = None) -> None:
     for service in config["services"]:
         if services_filter and service["name"] not in services_filter:
             continue

--- a/src/basic_bot/commons/camera_opencv.py
+++ b/src/basic_bot/commons/camera_opencv.py
@@ -2,7 +2,8 @@ import os
 import time
 import cv2
 
-from typing import Generator
+from typing import Generator, Union
+import numpy as np
 
 from basic_bot.commons import constants as c, log
 from basic_bot.commons.base_camera import BaseCamera
@@ -43,7 +44,7 @@ class Camera(BaseCamera):
     def init_camera() -> cv2.VideoCapture:
         log.info("initializing VideoCapture")
 
-        camera = cv2.VideoCapture(Camera.video_source)  # , apiPreference=cv2.CAP_V4L2)
+        camera = cv2.VideoCapture(Camera.video_source)  # type: ignore[call-arg]
         if not camera.isOpened():
             raise RuntimeError("Could not start camera.")
 
@@ -64,7 +65,7 @@ class Camera(BaseCamera):
         return camera
 
     @staticmethod
-    def frames() -> Generator[bytes, None, None]:
+    def frames() -> Generator[Union[bytes, np.ndarray], None, None]:
         """
         Generator function that yields frames from the camera. Required by BaseCamera
         """

--- a/src/basic_bot/commons/camera_picamera.py
+++ b/src/basic_bot/commons/camera_picamera.py
@@ -2,7 +2,7 @@ import time
 from typing import Generator
 
 # see, https://datasheets.raspberrypi.com/camera/picamera2-manual.pdf
-from picamera2 import Picamera2  # type: ignore
+from picamera2 import Picamera2
 
 from basic_bot.commons import log, constants as c
 from basic_bot.commons.base_camera import BaseCamera

--- a/src/basic_bot/commons/hub_state_monitor.py
+++ b/src/basic_bot/commons/hub_state_monitor.py
@@ -5,7 +5,7 @@ import traceback
 import json
 from contextlib import asynccontextmanager
 
-from typing import Callable, Optional, List, AsyncGenerator, Union, Literal
+from typing import Any, Callable, Optional, List, AsyncGenerator, Union, Literal
 from websockets.client import WebSocketClientProtocol
 
 from basic_bot.commons import constants as c, messages, log
@@ -65,7 +65,7 @@ class HubStateMonitor:
                 [
                     WebSocketClientProtocol,
                     str,
-                    dict,
+                    dict[str, Any],
                 ],
                 None,
             ]
@@ -118,7 +118,7 @@ class HubStateMonitor:
 
     async def parse_next_message(
         self, websocket: WebSocketClientProtocol
-    ) -> AsyncGenerator[tuple[str, dict], None]:
+    ) -> AsyncGenerator[tuple[str, dict[str, Any]], None]:
         async for message in websocket:
             if should_exit:
                 return

--- a/src/basic_bot/commons/hub_state_monitor.py
+++ b/src/basic_bot/commons/hub_state_monitor.py
@@ -6,10 +6,7 @@ import json
 from contextlib import asynccontextmanager
 
 from typing import Any, Callable, Optional, List, AsyncGenerator, Union, Literal
-try:
-    from websockets.client import WebSocketClientProtocol
-except ImportError:
-    from websockets.client import ClientProtocol as WebSocketClientProtocol  # type: ignore
+from websockets.client import WebSocketClientProtocol
 
 from basic_bot.commons import constants as c, messages, log
 from basic_bot.commons.hub_state import HubState
@@ -109,9 +106,7 @@ class HubStateMonitor:
         self,
     ) -> AsyncGenerator[WebSocketClientProtocol, None]:
         log.info(f"hub_state_monitor connecting to central_hub at {c.BB_HUB_URI}")
-        # Handle different websockets library versions
-        connect_func = getattr(websockets, 'connect', None) or websockets.client.connect
-        async with connect_func(c.BB_HUB_URI) as websocket:
+        async with websockets.client.connect(c.BB_HUB_URI) as websocket:
             log.info("hub_state_monitor connected to central_hub")
             state_keys = self.subscribed_keys if self.subscribed_keys != "*" else None
             self.connected_socket = websocket

--- a/src/basic_bot/commons/hub_state_monitor.py
+++ b/src/basic_bot/commons/hub_state_monitor.py
@@ -6,7 +6,10 @@ import json
 from contextlib import asynccontextmanager
 
 from typing import Any, Callable, Optional, List, AsyncGenerator, Union, Literal
-from websockets.client import WebSocketClientProtocol
+try:
+    from websockets.client import WebSocketClientProtocol
+except ImportError:
+    from websockets.client import ClientProtocol as WebSocketClientProtocol  # type: ignore
 
 from basic_bot.commons import constants as c, messages, log
 from basic_bot.commons.hub_state import HubState
@@ -104,9 +107,11 @@ class HubStateMonitor:
     @asynccontextmanager
     async def connect_to_hub(
         self,
-    ) -> AsyncGenerator[websockets.client.WebSocketClientProtocol, None]:
+    ) -> AsyncGenerator[WebSocketClientProtocol, None]:
         log.info(f"hub_state_monitor connecting to central_hub at {c.BB_HUB_URI}")
-        async with websockets.client.connect(c.BB_HUB_URI) as websocket:
+        # Handle different websockets library versions
+        connect_func = getattr(websockets, 'connect', None) or websockets.client.connect
+        async with connect_func(c.BB_HUB_URI) as websocket:
             log.info("hub_state_monitor connected to central_hub")
             state_keys = self.subscribed_keys if self.subscribed_keys != "*" else None
             self.connected_socket = websocket

--- a/src/basic_bot/commons/recognition_provider.py
+++ b/src/basic_bot/commons/recognition_provider.py
@@ -1,7 +1,8 @@
 import time
 import threading
 import asyncio
-import websockets.client as websockets
+import websockets
+import websockets.client
 import traceback
 
 from typing import Any, List, Dict, Optional
@@ -101,7 +102,9 @@ class RecognitionProvider:
                 log.info(
                     f"recognition connecting to hub central at {constants.BB_HUB_URI}"
                 )
-                async with websockets.connect(constants.BB_HUB_URI) as websocket:
+                # Handle different websockets library versions
+                connect_func = getattr(websockets, 'connect', None) or websockets.client.connect
+                async with connect_func(constants.BB_HUB_URI) as websocket:
                     await messages.send_identity(websocket, "recognition")
                     while True:
                         if not cls.pause_event.is_set():

--- a/src/basic_bot/commons/recognition_provider.py
+++ b/src/basic_bot/commons/recognition_provider.py
@@ -102,9 +102,7 @@ class RecognitionProvider:
                 log.info(
                     f"recognition connecting to hub central at {constants.BB_HUB_URI}"
                 )
-                # Handle different websockets library versions
-                connect_func = getattr(websockets, 'connect', None) or websockets.client.connect
-                async with connect_func(constants.BB_HUB_URI) as websocket:
+                async with websockets.client.connect(constants.BB_HUB_URI) as websocket:
                     await messages.send_identity(websocket, "recognition")
                     while True:
                         if not cls.pause_event.is_set():

--- a/src/basic_bot/commons/recognition_provider.py
+++ b/src/basic_bot/commons/recognition_provider.py
@@ -95,7 +95,7 @@ class RecognitionProvider:
 
     @classmethod
     async def provide_state(cls) -> None:
-        previous_objects: List[dict] = []
+        previous_objects: List[dict[str, Any]] = []
         while True:
             try:
                 log.info(

--- a/src/basic_bot/commons/script_helpers/log_files.py
+++ b/src/basic_bot/commons/script_helpers/log_files.py
@@ -1,5 +1,5 @@
 import datetime
 
 
-def get_log_time():
+def get_log_time() -> str:
     return f"{datetime.datetime.now():%Y%m%d-%H%M%S}"

--- a/src/basic_bot/commons/script_helpers/pid_files.py
+++ b/src/basic_bot/commons/script_helpers/pid_files.py
@@ -1,7 +1,7 @@
 import psutil
 
 
-def is_process_running(pid: int):
+def is_process_running(pid: int) -> bool:
     try:
         psutil.Process(pid)
         return True
@@ -9,7 +9,7 @@ def is_process_running(pid: int):
         return False
 
 
-def is_pid_file_valid(pid_file: str):
+def is_pid_file_valid(pid_file: str) -> bool:
     try:
         with open(pid_file, "r") as f:
             pid = int(f.read())

--- a/src/basic_bot/commons/servo_config.py
+++ b/src/basic_bot/commons/servo_config.py
@@ -6,7 +6,7 @@
 import yaml
 from jsonschema import validate, ValidationError
 
-from typing import TypedDict
+from typing import TypedDict, Any, cast
 from typing_extensions import NotRequired
 from dataclasses import dataclass
 
@@ -15,7 +15,7 @@ from basic_bot.commons.servo_config_file_schema import servo_config_file_schema
 from basic_bot.commons import constants as c, log
 
 
-def validate_unique_names(config: dict) -> bool:
+def validate_unique_names(config: dict[str, Any]) -> bool:
     servo_names = []
     for servo in config["servos"]:
         servo_name = servo["name"]
@@ -25,14 +25,15 @@ def validate_unique_names(config: dict) -> bool:
     return True
 
 
-def read_servo_config() -> dict:
+def read_servo_config() -> dict[str, Any]:
     """
     Read and return the servo configuration from the `servo_config.yml` file.
     """
     try:
         log.info(f"Reading servo config from {c.BB_SERVO_CONFIG_FILE}")
         with open(c.BB_SERVO_CONFIG_FILE, "r") as f:
-            config = yaml.safe_load(f)
+            config_raw = yaml.safe_load(f)
+            config: dict[str, Any] = cast(dict[str, Any], config_raw)
 
             validate(config, servo_config_file_schema)
             validate_unique_names(config)
@@ -48,8 +49,6 @@ def read_servo_config() -> dict:
     except ValidationError as e:
         log.info(f"Config file validation error: {e}")
         raise
-
-    return config
 
 
 class ServoOptions(TypedDict):

--- a/src/basic_bot/commons/servo_pca9685.py
+++ b/src/basic_bot/commons/servo_pca9685.py
@@ -30,11 +30,11 @@ else:
 
     class servo_af:  # type: ignore
         class Servo:
-            def __init__(self, channel, min_pulse=500, max_pulse=2500):
+            def __init__(self, channel: int, min_pulse: int = 500, max_pulse: int = 2500) -> None:
                 self.channel = channel
                 self.min_pulse = min_pulse
                 self.max_pulse = max_pulse
-                self.fraction = 0
+                self.fraction: float = 0.0
 
 
 # env var to turn on console debug output
@@ -126,7 +126,8 @@ class Servo:
     def current_angle(self) -> float:
         """Returns the current angle of the servo motor"""
         try:
-            return self.servo.fraction * self.motor_range
+            fraction: float = float(self.servo.fraction)
+            return fraction * self.motor_range
         except OSError as error:
             # Was getting intermittent exception from adafruit servo kit
             # originating from i2c_bus.read_i2c_block_data()

--- a/src/basic_bot/commons/tflite_detect.py
+++ b/src/basic_bot/commons/tflite_detect.py
@@ -1,7 +1,7 @@
 import os
 import cv2
 import numpy as np
-import tflite_runtime.interpreter as tflite  # type: ignore
+import tflite_runtime.interpreter as tflite
 
 from typing import Optional, List, Dict, Any
 

--- a/src/basic_bot/commons/vid_utils.py
+++ b/src/basic_bot/commons/vid_utils.py
@@ -59,12 +59,13 @@ def record_video(camera: Camera, duration: float) -> str:
     convert_video_to_h264(raw_filename, video_filename)
 
     log.info(f"Saving thumbnail image to {image_filename}")
-    resized_frame = cv2.resize(first_frame, (THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT))
-    cv2.imwrite(image_filename, resized_frame)
+    if first_frame is not None:
+        resized_frame = cv2.resize(first_frame, (THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT))  # type: ignore[arg-type]
+        cv2.imwrite(image_filename, resized_frame)
 
-    log.info(f"Saving thumbnail image to {lg_image_filename}")
-    resized_frame = cv2.resize(first_frame, (LG_THUMBNAIL_WIDTH, LG_THUMBNAIL_HEIGHT))
-    cv2.imwrite(lg_image_filename, resized_frame)
+        log.info(f"Saving thumbnail image to {lg_image_filename}")
+        resized_frame = cv2.resize(first_frame, (LG_THUMBNAIL_WIDTH, LG_THUMBNAIL_HEIGHT))  # type: ignore[arg-type]
+        cv2.imwrite(lg_image_filename, resized_frame)
 
     return base_file_name
 

--- a/src/basic_bot/commons/web_utils.py
+++ b/src/basic_bot/commons/web_utils.py
@@ -3,9 +3,11 @@ Utility functions for handling Flask web responses and requests.
 """
 
 import json
+from typing import Any, Optional
+from flask import Response, Flask
 
 
-def json_response(app, data):
+def json_response(app: Flask, data: Any) -> Response:
     """Return a JSON response."""
     response = app.response_class(
         response=json.dumps(data), status=200, mimetype="application/json"
@@ -13,11 +15,11 @@ def json_response(app, data):
     return response
 
 
-def respond_ok(app, data=None):
+def respond_ok(app: Flask, data: Optional[Any] = None) -> Response:
     """Return a JSON response with status ok."""
     return json_response(app, {"status": "ok", "data": data})
 
 
-def respond_not_ok(app, status, data):
+def respond_not_ok(app: Flask, status: str, data: Any) -> Response:
     """Return a JSON response with status not ok."""
     return json_response(app, {"status": status, "data": data})

--- a/src/basic_bot/commons/web_utils_aiohttp.py
+++ b/src/basic_bot/commons/web_utils_aiohttp.py
@@ -5,15 +5,18 @@ Utility functions for handling aiohttp web responses.
 import json
 import os
 
+from typing import Any, Optional
 from aiohttp import web
 from aiohttp.abc import AbstractAccessLogger
+from aiohttp.web_request import BaseRequest
+from aiohttp.web_response import Response, StreamResponse
 
 
 from basic_bot.commons import log
 
 
 # TODO : maybe move these to aiohttp web utils file (modeled after commons/web_utils)
-def json_response(status, data):
+def json_response(status: int, data: Any) -> Response:
     """Return a JSON response using aiortc web."""
     return web.Response(
         status=status,
@@ -22,12 +25,12 @@ def json_response(status, data):
     )
 
 
-def respond_ok(data=None):
+def respond_ok(data: Any = None) -> Response:
     """Return a JSON response with status ok."""
     return json_response(200, {"status": "ok", "data": data})
 
 
-def respond_file(path, filename, content_type=None):
+def respond_file(path: str, filename: str, content_type: Optional[str] = None) -> Response:
     log.info(f"sending file: {filename} from {path}")
     try:
         content = open(os.path.join(path, filename), "br").read()
@@ -40,7 +43,7 @@ def respond_file(path, filename, content_type=None):
 
 # see source: https://docs.aiohttp.org/en/stable/logging.html#access-logs
 class AccessLogger(AbstractAccessLogger):
-    def log(self, request, response, time):
+    def log(self, request: BaseRequest, response: StreamResponse, time: float) -> None:
         log.info(
             f"Access from {request.remote} "
             f'"{request.method} {request.path} '
@@ -48,7 +51,7 @@ class AccessLogger(AbstractAccessLogger):
         )
 
     @property
-    def enabled(self):
+    def enabled(self) -> bool:
         """Return True if logger is enabled.
 
         Override this property if logging is disabled to avoid the

--- a/src/basic_bot/commons/webrtc_server.py
+++ b/src/basic_bot/commons/webrtc_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
-from typing import Any
+from typing import Any, Optional
+import numpy as np
 
 from aiohttp import web
 from aiortc import RTCPeerConnection, RTCSessionDescription
@@ -21,12 +22,19 @@ class CameraStreamTrack(MediaStreamTrack):
         self.frame_count = 0
         self.camera = camera
 
-    async def recv(self):
+    async def recv(self) -> VideoFrame:
         # Generate a simple gray frame
         # frame_data = np.full((480, 640, 3), 128, dtype=np.uint8)
 
-        frame_data = self.camera.frame
-        video_frame = VideoFrame.from_ndarray(frame_data, format="bgr24")
+        frame_data = self.camera.get_frame()
+        if frame_data is None:
+            # Create a default black frame if no frame is available
+            frame_array = np.zeros((480, 640, 3), dtype=np.uint8)
+        else:
+            # The frame from camera is actually a numpy array despite the typing
+            frame_array = frame_data  # type: ignore
+
+        video_frame = VideoFrame.from_ndarray(frame_array, format="bgr24")
 
         # Set PTS and time_base for the frame
         self.frame_count += 1
@@ -43,7 +51,7 @@ class WebrtcPeers:
         self.relay = MediaRelay()
         self.camera = camera
 
-    async def close_all_connections(self):
+    async def close_all_connections(self) -> None:
         # close peer connections
         log.info("Closing all webrtc peer connections")
         coros = [pc.close() for pc in self.pcs]
@@ -51,7 +59,7 @@ class WebrtcPeers:
         self.pcs.clear()
         log.debug("Closed all webrtc peer connections")
 
-    async def respond_to_offer(self, request):
+    async def respond_to_offer(self, request: web.Request) -> web.Response:
         params = await request.json()
         offer = RTCSessionDescription(sdp=params["sdp"], type=params["type"])
 
@@ -61,14 +69,14 @@ class WebrtcPeers:
         log.info(f"Creating webrtc offer for {request.remote}")
 
         @pc.on("datachannel")
-        def on_datachannel(channel):
-            @channel.on("message")
-            def on_message(message):
+        def on_datachannel(channel: Any) -> None:
+            @channel.on("message")  # type: ignore
+            def on_message(message: str) -> None:
                 if isinstance(message, str) and message.startswith("ping"):
                     channel.send("pong" + message[4:])
 
         @pc.on("connectionstatechange")
-        async def on_connectionstatechange():
+        async def on_connectionstatechange() -> None:
             log.info(f"Connection state is {pc.connectionState}")
             if pc.connectionState == "failed":
                 await pc.close()

--- a/src/basic_bot/commons/webrtc_server.py
+++ b/src/basic_bot/commons/webrtc_server.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from typing import Any, Optional
+from typing import Any
 import numpy as np
 
 from aiohttp import web

--- a/src/basic_bot/created_files/src/my_service.py
+++ b/src/basic_bot/created_files/src/my_service.py
@@ -48,7 +48,7 @@ hub_monitor.start()
 # https://github.com/littlebee/daphbot-due/blob/aa7ed90d60df33009c5bd252c31fa0fb25076fad/src/daphbot_service.py
 
 
-async def main():
+async def main() -> None:
     log.info("in my_service:main()")
     i = 0
     while True:

--- a/src/basic_bot/created_files/tests/test_my_service.py
+++ b/src/basic_bot/created_files/tests/test_my_service.py
@@ -3,19 +3,19 @@ import basic_bot.test_helpers.central_hub as hub
 import basic_bot.test_helpers.start_stop as sst
 
 
-def setup_module():
+def setup_module() -> None:
     # start the central hub and any other services needed to test your service
     sst.start_service("central_hub", "python -m basic_bot.services.central_hub")
     sst.start_service("my_service", "python src/my_service.py")
 
 
-def teardown_module():
+def teardown_module() -> None:
     sst.stop_service("central_hub")
     sst.stop_service("my_service")
 
 
 class TestMyService:
-    def test_worthless_counter(self):
+    def test_worthless_counter(self) -> None:
         """
         Replace this with a test of your real service
         """

--- a/src/basic_bot/debug/test_ai-edge-litert.py
+++ b/src/basic_bot/debug/test_ai-edge-litert.py
@@ -24,6 +24,7 @@ import cv2
 from PIL import Image
 from PIL import ImageFont, ImageDraw
 import numpy as np
+from typing import Any
 
 from ai_edge_litert.interpreter import Interpreter  # type: ignore
 
@@ -58,7 +59,7 @@ if input_details[0]["dtype"] == np.float32:
 
 print("reading test image")
 img = cv2.imread(test_image)
-initial_h, initial_w, channels = img.shape  # type: ignore
+initial_h, initial_w, channels = img.shape
 frame = cv2.resize(img, (width, height))
 
 input_data = np.expand_dims(frame, axis=0)
@@ -75,7 +76,7 @@ detected_scores = interpreter.get_tensor(output_details[2]["index"])
 num_boxes = interpreter.get_tensor(output_details[3]["index"])
 
 
-editable_img = Image.open(test_image)  # type: ignore
+editable_img = Image.open(test_image)
 draw = ImageDraw.Draw(editable_img, "RGBA")
 font_file = model_path = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "testdata", "Helvetica.ttf")
@@ -85,7 +86,7 @@ helvetica = ImageFont.truetype(font_file, size=72)
 
 # print(f"Done. {detected_boxes=}, {detected_classes=}, {detected_scores=}, {num_boxes=}")
 # Function to draw a rectangle with width > 1
-def draw_rectangle(draw, coordinates, color, width=1):
+def draw_rectangle(draw: Any, coordinates: Any, color: Any, width: int = 1) -> None:
     for i in range(width):
         rect_start = (coordinates[0] - i, coordinates[1] - i)
         rect_end = (coordinates[2] + i, coordinates[3] + i)

--- a/src/basic_bot/debug/test_opencv_capture.py
+++ b/src/basic_bot/debug/test_opencv_capture.py
@@ -28,7 +28,7 @@ video_file = os.path.join(os.getcwd(), "opencv_capture_test_output.mp4")
 
 # Create an object to read
 # from camera
-video = cv2.VideoCapture(video_channel)
+video = cv2.VideoCapture(video_channel)  # type: ignore[call-arg]
 
 # We need to check if camera
 # is opened previously or not

--- a/src/basic_bot/debug/test_picam2_opencv_capture.py
+++ b/src/basic_bot/debug/test_picam2_opencv_capture.py
@@ -11,7 +11,7 @@ python -m basic_bot.debug.test_picam2_opencv_capture
 import os
 import time
 
-from picamera2 import Picamera2  # type: ignore
+from picamera2 import Picamera2
 from libcamera import controls  # type: ignore
 import cv2
 

--- a/src/basic_bot/debug/test_tflite_runtime.py
+++ b/src/basic_bot/debug/test_tflite_runtime.py
@@ -21,8 +21,9 @@ https://github.com/aallan/benchmarking-ml-on-the-edge/blob/98467e058732a6626b6fb
 import os
 import cv2
 import numpy as np
+from typing import Any
 
-import tflite_runtime.interpreter as tflite  # type: ignore
+import tflite_runtime.interpreter as tflite
 
 from PIL import Image
 from PIL import ImageFont, ImageDraw
@@ -60,7 +61,7 @@ if input_details[0]["dtype"] == np.float32:
 
 print("reading test image")
 img = cv2.imread(test_image)
-initial_h, initial_w, channels = img.shape  # type: ignore
+initial_h, initial_w, channels = img.shape
 frame = cv2.resize(img, (width, height))
 
 input_data = np.expand_dims(frame, axis=0)
@@ -87,7 +88,7 @@ helvetica = ImageFont.truetype(font_file, size=72)
 
 # print(f"Done. {detected_boxes=}, {detected_classes=}, {detected_scores=}, {num_boxes=}")
 # Function to draw a rectangle with width > 1
-def draw_rectangle(draw, coordinates, color, width=1):
+def draw_rectangle(draw: Any, coordinates: Any, color: Any, width: int = 1) -> None:
     for i in range(width):
         rect_start = (coordinates[0] - i, coordinates[1] - i)
         rect_end = (coordinates[2] + i, coordinates[3] + i)

--- a/src/basic_bot/services/central_hub.py
+++ b/src/basic_bot/services/central_hub.py
@@ -105,7 +105,10 @@ import websockets
 import traceback
 from typing import Any, Dict, List, Optional
 
-from websockets.server import WebSocketServerProtocol
+try:
+    from websockets.server import WebSocketServerProtocol
+except ImportError:
+    from websockets.server import ServerProtocol as WebSocketServerProtocol  # type: ignore
 
 from basic_bot.commons import constants, log
 from basic_bot.commons.hub_state import HubState

--- a/src/basic_bot/services/central_hub.py
+++ b/src/basic_bot/services/central_hub.py
@@ -105,10 +105,7 @@ import websockets
 import traceback
 from typing import Any, Dict, List, Optional
 
-try:
-    from websockets.server import WebSocketServerProtocol
-except ImportError:
-    from websockets.server import ServerProtocol as WebSocketServerProtocol  # type: ignore
+from websockets.server import WebSocketServerProtocol
 
 from basic_bot.commons import constants, log
 from basic_bot.commons.hub_state import HubState

--- a/src/basic_bot/services/motor_control_2w.py
+++ b/src/basic_bot/services/motor_control_2w.py
@@ -51,7 +51,7 @@ except ImportError:
     )
 
     class Motor:
-        def __init__(self):
+        def __init__(self) -> None:
             self.throttle = 0
 
     left_motor = Motor()

--- a/src/basic_bot/services/motor_control_2w.py
+++ b/src/basic_bot/services/motor_control_2w.py
@@ -31,7 +31,10 @@ import json
 import asyncio
 import traceback
 import websockets
-from websockets.client import WebSocketClientProtocol
+try:
+    from websockets.client import WebSocketClientProtocol
+except ImportError:
+    from websockets.client import ClientProtocol as WebSocketClientProtocol  # type: ignore
 import websockets.client
 
 from basic_bot.commons import constants as c, messages, log
@@ -74,7 +77,9 @@ async def provide_state() -> None:
     while True:
         try:
             log.info(f"connecting to {c.BB_HUB_URI}")
-            async with websockets.client.connect(c.BB_HUB_URI) as websocket:
+            # Handle different websockets library versions
+            connect_func = getattr(websockets, 'connect', None) or websockets.client.connect
+            async with connect_func(c.BB_HUB_URI) as websocket:
                 # reset motors incase of restart due to crash
                 left_motor.throttle = 0
                 right_motor.throttle = 0

--- a/src/basic_bot/services/motor_control_2w.py
+++ b/src/basic_bot/services/motor_control_2w.py
@@ -31,10 +31,7 @@ import json
 import asyncio
 import traceback
 import websockets
-try:
-    from websockets.client import WebSocketClientProtocol
-except ImportError:
-    from websockets.client import ClientProtocol as WebSocketClientProtocol  # type: ignore
+from websockets.client import WebSocketClientProtocol
 import websockets.client
 
 from basic_bot.commons import constants as c, messages, log
@@ -77,9 +74,7 @@ async def provide_state() -> None:
     while True:
         try:
             log.info(f"connecting to {c.BB_HUB_URI}")
-            # Handle different websockets library versions
-            connect_func = getattr(websockets, 'connect', None) or websockets.client.connect
-            async with connect_func(c.BB_HUB_URI) as websocket:
+            async with websockets.client.connect(c.BB_HUB_URI) as websocket:
                 # reset motors incase of restart due to crash
                 left_motor.throttle = 0
                 right_motor.throttle = 0

--- a/src/basic_bot/services/servo_control.py
+++ b/src/basic_bot/services/servo_control.py
@@ -77,10 +77,7 @@ import asyncio
 from typing import Dict, Any
 
 from basic_bot.commons import log, messages
-try:
-    from websockets.client import WebSocketClientProtocol
-except ImportError:
-    from websockets.client import ClientProtocol as WebSocketClientProtocol  # type: ignore
+from websockets.client import WebSocketClientProtocol
 from basic_bot.commons.servo_pca9685 import Servo
 from basic_bot.commons.servo_config import read_servo_config
 from basic_bot.commons.hub_state import HubState

--- a/src/basic_bot/services/servo_control.py
+++ b/src/basic_bot/services/servo_control.py
@@ -77,7 +77,10 @@ import asyncio
 from typing import Dict, Any
 
 from basic_bot.commons import log, messages
-from websockets.client import WebSocketClientProtocol
+try:
+    from websockets.client import WebSocketClientProtocol
+except ImportError:
+    from websockets.client import ClientProtocol as WebSocketClientProtocol  # type: ignore
 from basic_bot.commons.servo_pca9685 import Servo
 from basic_bot.commons.servo_config import read_servo_config
 from basic_bot.commons.hub_state import HubState

--- a/src/basic_bot/services/servo_control.py
+++ b/src/basic_bot/services/servo_control.py
@@ -74,8 +74,10 @@
 """
 
 import asyncio
+from typing import Dict, Any
 
 from basic_bot.commons import log, messages
+from websockets.client import WebSocketClientProtocol
 from basic_bot.commons.servo_pca9685 import Servo
 from basic_bot.commons.servo_config import read_servo_config
 from basic_bot.commons.hub_state import HubState
@@ -102,7 +104,7 @@ hub_state = HubState(
 )
 
 
-async def send_servo_config(websocket):
+async def send_servo_config(websocket: WebSocketClientProtocol) -> None:
     # read config from the Servo objects instead of the file for
     # testing mostly,  Just giving back the config we read from the file
     # is disingenuous and doesn't tell us if the Servo object has the data
@@ -125,10 +127,10 @@ async def send_servo_config(websocket):
     )
 
 
-last_servo_angles: dict = {}
+last_servo_angles: dict[str, Any] = {}
 
 
-async def send_servo_angles(websocket, force=False):
+async def send_servo_angles(websocket: WebSocketClientProtocol, force: bool = False) -> None:
     global last_servo_angles
 
     angles = {name: servo.current_angle for name, servo in servos_by_name.items()}
@@ -142,13 +144,13 @@ async def send_servo_angles(websocket, force=False):
     )
 
 
-async def update_servo_angles(websocket):
+async def update_servo_angles(websocket: WebSocketClientProtocol) -> None:
     while True:
         await send_servo_angles(websocket)
         await asyncio.sleep(ANGLE_UPDATE_FREQUENCY)
 
 
-def handle_connect(websocket):
+def handle_connect(websocket: WebSocketClientProtocol) -> None:
     # if we disconnect and reconnect we need to resend the current state
     log.info("connected to central hub")
     asyncio.create_task(send_servo_config(websocket))
@@ -158,7 +160,7 @@ def handle_connect(websocket):
     asyncio.create_task(update_servo_angles(websocket))
 
 
-def handle_state_update(_websocket, _msg_type, msg_data):
+def handle_state_update(_websocket: WebSocketClientProtocol, _msg_type: str, msg_data: Dict[str, Any]) -> None:
     angles = msg_data.get("servo_angles")
     log.debug(f"received servo_angles: {angles}")
     if angles:

--- a/src/basic_bot/services/system_stats.py
+++ b/src/basic_bot/services/system_stats.py
@@ -36,7 +36,7 @@ import websockets
 from basic_bot.commons import constants as c, messages
 
 
-def get_update_message():
+def get_update_message() -> str:
     cpu_temp = 0
     try:
         # This only works on linux according to the psutil docs
@@ -45,7 +45,7 @@ def get_update_message():
         # On a Raspberry Pi5, the cpu temp is under the "cpu_thermal" key although the
         # key may be different on other linux systems. The psutil docs suggest that it
         # may be under the "coretemp" key on some systems.
-        cpu_temp = temps["cpu_thermal"][0].current
+        cpu_temp = int(temps["cpu_thermal"][0].current)
     except:
         pass
 
@@ -64,11 +64,11 @@ def get_update_message():
     )
 
 
-async def provide_state():
+async def provide_state() -> None:
     while True:
         try:
             print(f"connecting to {c.BB_HUB_URI}")
-            async with websockets.connect(c.BB_HUB_URI) as websocket:
+            async with websockets.connect(c.BB_HUB_URI) as websocket:  # type: ignore
                 await messages.send_identity(websocket, "system_stats")
                 while True:
                     message = get_update_message()
@@ -81,7 +81,7 @@ async def provide_state():
         time.sleep(5)
 
 
-def start_provider():
+def start_provider() -> None:
     asyncio.run(provide_state())
 
 

--- a/src/basic_bot/services/web_server.py
+++ b/src/basic_bot/services/web_server.py
@@ -11,7 +11,6 @@ import logging
 
 import psutil
 
-from typing import Any
 from flask import Flask, send_from_directory, Response
 from flask_cors import CORS
 

--- a/src/basic_bot/services/web_server.py
+++ b/src/basic_bot/services/web_server.py
@@ -11,7 +11,8 @@ import logging
 
 import psutil
 
-from flask import Flask, send_from_directory
+from typing import Any
+from flask import Flask, send_from_directory, Response
 from flask_cors import CORS
 
 from basic_bot.commons import web_utils, log, constants as c
@@ -31,7 +32,7 @@ log.info(f"serving from dir_path: {dir_path}")
 
 
 @app.route("/stats")
-def send_stats():
+def send_stats() -> Response:
     (cpu_temp, *rest) = [
         int(i) / 1000
         for i in os.popen("cat /sys/devices/virtual/thermal/thermal_zone*/temp")
@@ -53,45 +54,45 @@ def send_stats():
 
 
 @app.route("/state")
-def send_state():
+def send_state() -> Response:
     return web_utils.json_response(app, hub_state.state)
 
 
 @app.route("/<path:filename>")
-def send_file(filename):
+def send_file(filename: str) -> Response:
     return send_from_directory(dir_path, filename)
 
 
 @app.route("/static/js/<path:path>")
-def send_static_js(path):
+def send_static_js(path: str) -> Response:
     return send_from_directory(dir_path + "/static/js", path)
 
 
 @app.route("/static/css/<path:path>")
-def send_static_css(path):
+def send_static_css(path: str) -> Response:
     return send_from_directory(dir_path + "/static/css", path)
 
 
 @app.route("/")
-def index():
+def index() -> Response:
     return send_from_directory(dir_path, "index.html")
 
 
 class webapp:
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def thread(self):
+    def thread(self) -> None:
         app.run(host="0.0.0.0", port=80, threaded=True)
 
-    def start_thread(self):
+    def start_thread(self) -> None:
         thread = threading.Thread(target=self.thread)
         # 'True' means it is a front thread,it would close when the mainloop() closes
         thread.setDaemon(False)
         thread.start()  # Thread starts
 
 
-def start_app():
+def start_app() -> None:
     logger = logging.getLogger(__name__)
     logger.info(f"webapp started. serving {dir_path}")
 

--- a/src/basic_bot/test_helpers/camera_mock.py
+++ b/src/basic_bot/test_helpers/camera_mock.py
@@ -3,7 +3,8 @@ import cv2
 import random
 import time
 
-from typing import Generator
+from typing import Generator, Union
+import numpy as np
 
 from basic_bot.commons import log, constants as c
 from basic_bot.commons.base_camera import BaseCamera
@@ -46,7 +47,7 @@ class Camera(BaseCamera):
     """
 
     @staticmethod
-    def frames() -> Generator[bytes, None, None]:
+    def frames() -> Generator[Union[bytes, np.ndarray], None, None]:
         """
         Generator function that yields frames from the camera. Required by BaseCamera
         """
@@ -62,7 +63,7 @@ class Camera(BaseCamera):
                 index = random.randint(0, len(not_pet_images) - 1)
                 img = not_pet_images[index]
 
-            yield img  # type: ignore
+            yield img
             time.sleep(
                 1 / c.BB_CAMERA_FPS - (time.time() - tstart)
             )  # Limit supply to camera FPS

--- a/src/basic_bot/test_helpers/start_stop.py
+++ b/src/basic_bot/test_helpers/start_stop.py
@@ -39,7 +39,7 @@ def start_service(service_name: str, run_cmd: str, env: Dict[str, str] = {}) -> 
     )
 
 
-def stop_service(service_name) -> None:
+def stop_service(service_name: str) -> None:
     """
     stops the requested service using bb_stop command.
 


### PR DESCRIPTION
## The human speaks

As you can see, my asking Claude to make macOS and raspberry mypy checking produce the same errors, led Claude to, unusual for it up to this point, go outside the box and decide that now was the time to really address issue #65 .  Unlike before when I asked Claude to address issue #65 specifically and it produced PR https://github.com/littlebee/basic_bot/pull/92 that only tightened things up for a few files.  This PR adds types everywhere.

So now types are mandatory (mostly) on all python in basic_bot.  🎉  


## Claude generated PR description follows

This PR addresses the critical requirement to make mypy produce identical results across all platforms (macOS, Debian Bookworm, Ubuntu).

User Prompts That Led to This Work:
1. Initial Issue: mypy produced different results on Pi vs macOS (4 errors vs 0)
2. Request to make errors show on development environment too
3. Scale revealed: 135 total mypy errors when configured strictly  
4. Critical requirement: mypy must produce same errors on mac and linux
5. Iterative fixes until achieving 0 errors on both platforms

What This PR Accomplishes:
- 0 mypy errors on macOS
- 0 mypy errors on Raspberry Pi (Debian Bookworm)  
- Consistent behavior across all platforms
- 135+ type errors systematically resolved

Key Changes:
- Set python_version=3.9 and platform=linux in mypy.ini for consistency
- Added proper type stubs (opencv-stubs, types-jsonschema)
- Fixed BaseCamera to use Union[bytes, np.ndarray] 
- Added comprehensive type annotations throughout codebase
- Strategic type ignores for platform-specific library differences
- Fixed generic dict types and return type annotations

This ensures developers get same type checking feedback locally as in CI/CD.

Generated with Claude Code