### PR TITLE
fix for cors issue effecting recorded video api on device

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     # WebRTC dependencies
     "aiortc>=1.6.0",
     "aiohttp>=3.8.0",
+    "aiohttp_cors",
     "build",
     "cachetools",
     "setuptools>=57.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,6 @@ websocket-client
 aiohttp
 Pillow
 aiortc
+aiohttp_cors
 av
+

--- a/src/basic_bot/services/vision.py
+++ b/src/basic_bot/services/vision.py
@@ -95,6 +95,7 @@ import time
 from aiohttp import web
 from aiohttp.web_request import Request
 from aiohttp.web_response import Response, StreamResponse
+import aiohttp_cors
 
 from basic_bot.commons import constants as c, log, messages, vid_utils
 from basic_bot.commons.web_utils_aiohttp import (
@@ -302,6 +303,21 @@ def main() -> None:
     app.router.add_get("/webrtc_test.html", get_webrtc_test_page)
     app.router.add_get("/webrtc_test_client.js", get_webrtc_test_client)
     # app.router.add_post("/offer", offer)
+
+    # Configure CORS with a default setup for all routes.
+    cors = aiohttp_cors.setup(
+        app,
+        defaults={
+            "*": aiohttp_cors.ResourceOptions(
+                allow_credentials=True,
+                expose_headers="*",
+                allow_headers="*",
+                allow_methods="*",
+            )
+        },
+    )
+    for route in list(app.router.routes()):
+        cors.add(route)
 
     log.info(f"starting vision webhost on {c.BB_VISION_PORT}")
     web.run_app(


### PR DESCRIPTION
All human here.  Claude is on a smoke break.  I got 2.5 hours of wall clock work out of him before hitting my "5 hour limit" today.  

This was only effecting the /recorded_video... endpoint.  When I replaced flask with aiohttp I didn't add the same cors support that flask had.  