### PR TITLE
Separate linting from build and add step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Run build and install
         run: ./install-dev.sh
 
+      - name: Run linters and type checker
+        run: ./lint.sh
+
       - name: Run tests
         run: |
           echo 'npm path:'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,13 @@ basic_bot is a Python-centric robotics platform that provides an ultra-lightweig
 
 ## Essential Commands
 
-### Build and Lint
+### Build
 ```bash
-# Build the entire project (includes linting and type checking)
+# Build the entire project using the `python -m build`
 ./build.sh
+
+# Run both linting and type checking
+./lint.sh
 
 # Run linting only
 python -m flake8 src/basic_bot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,11 @@ To build use the build.sh script:
 ./build.sh
 ```
 
-Note that build script also runs lint via flake8 and typechecking of python via mypy.
+## Linting and typechecking
+```sh
+./lint.sh
+```
+
 
 ## Installing locally
 

--- a/build.sh
+++ b/build.sh
@@ -13,11 +13,5 @@ cd ../../../..
 # fail on any error
 set -e
 
-echo "Linting..."
-python -m flake8 src/basic_bot
-
-echo "Running mypy (typechecker): $(python -m mypy --version)"
-python -m mypy src/basic_bot
-
 echo "Building pip package"
 python -m build

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# fail on any error
+set -e
+
+echo "Linting with flake8..."
+python -m flake8 src/basic_bot
+
+echo "Running mypy (typechecker): $(python -m mypy --version)"
+python -m mypy src/basic_bot
+


### PR DESCRIPTION
This has been causing some issues of late when new libs are added to pyproject.toml as deps of basic_bot, they also need to get put in requirements.txt so that they get installed in the ci workflow before the build install step is run.  This should make life a little easier (by like 4% at least)