### PR TITLE
Fix issue with vision service not stopping gracefully on bb_stop

### DIFF
--- a/src/basic_bot/services/vision.py
+++ b/src/basic_bot/services/vision.py
@@ -280,7 +280,7 @@ async def get_webrtc_test_client(_request: Request) -> Response:
 async def on_shutdown(_app: web.Application) -> None:
     await webrtc_peers.close_all_connections()
     mjpeg_video.stop()
-    if recognition:
+    if not c.BB_DISABLE_RECOGNITION_PROVIDER:
         recognition.stop()
     camera.stop()
     hub.stop()

--- a/src/basic_bot/services/vision.py
+++ b/src/basic_bot/services/vision.py
@@ -111,7 +111,9 @@ from basic_bot.commons.base_camera import BaseCamera
 from basic_bot.commons.webrtc_server import WebrtcPeers
 from basic_bot.commons.mjpeg_video import MjpegVideo
 
-if not c.BB_DISABLE_RECOGNITION_PROVIDER:
+if c.BB_DISABLE_RECOGNITION_PROVIDER:
+    log.info("Recognition provider is disabled (BB_DISABLE_RECOGNITION_PROVIDER)")
+else:
     from basic_bot.commons.recognition_provider import RecognitionProvider
 
 # this is mainly for debugging WebRTC and aiortc
@@ -278,6 +280,8 @@ async def get_webrtc_test_client(_request: Request) -> Response:
 async def on_shutdown(_app: web.Application) -> None:
     await webrtc_peers.close_all_connections()
     mjpeg_video.stop()
+    if recognition:
+        recognition.stop()
     camera.stop()
     hub.stop()
 


### PR DESCRIPTION
I think in the before times (when we used Flask in the vision service) Flask would force threads to exit at shutdown.

This PR adds an explicit `stop()` interface that will cause the recognition provider thread to exit with demur and intentionality. :)  