### PR TITLE
BB_LOG_DEBUG is no excuse to spam the logs :)

### DIFF
--- a/src/basic_bot/commons/tflite_detect.py
+++ b/src/basic_bot/commons/tflite_detect.py
@@ -76,7 +76,6 @@ class TFLiteDetect:
             input_data = (np.float32(input_data) - 127.5) / 127.5  # type: ignore
         self.interpreter.set_tensor(self.input_details[0]["index"], input_data)
 
-        log.debug("Running inference...")
         self.interpreter.invoke()
         detected_boxes = self.interpreter.get_tensor(self.output_details[0]["index"])
         detected_classes = self.interpreter.get_tensor(self.output_details[1]["index"])
@@ -102,5 +101,4 @@ class TFLiteDetect:
                         "confidence": score,
                     }
                 )
-        log.debug(f"tflite_detect results: {results}")
         return results


### PR DESCRIPTION
Note to be mindful and demure even when using log.debug().  Things that log a debug message on every frame of video at 30fps, for example, should probably be avoided as it causes a lot of noise when trying to debug something other than object detection. '