### PR TITLE
Fix bb_killall to work from any directory

### DIFF
--- a/src/basic_bot/bb_killall.py
+++ b/src/basic_bot/bb_killall.py
@@ -44,9 +44,15 @@ def main() -> None:
     else:
         print("No processes found matching the regex.")
 
-    # remove all files in the pids directory
-    for pid_file in os.listdir("./pids"):
-        os.remove(f"./pids/{pid_file}")
+    # remove all files in the local pids directory if it exists
+    if os.path.exists("./pids") and os.path.isdir("./pids"):
+        pid_files = os.listdir("./pids")
+        if pid_files:
+            print(f"Cleaning up {len(pid_files)} PID file(s) from ./pids")
+            for pid_file in pid_files:
+                os.remove(f"./pids/{pid_file}")
+        else:
+            print("No PID files to clean up in ./pids")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fixes bb_killall to work from any directory by adding conditional check for ./pids directory
- Prevents crashes when run outside project directories
- Provides informative messages about PID file cleanup
- Tested successfully on Raspberry Pi 5 with daphbot-due services

## Test plan
- [x] Tested bb_killall from random directory on pi5.local with daphbot-due services
- [x] Verified processes are killed globally regardless of run location
- [x] Confirmed no crashes when ./pids directory doesn't exist
- [x] Verified PID files are cleaned up when ./pids exists
- [x] Confirmed services restart successfully after killall

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)