### PR TITLE
Add bi-directional state control to webapp template

### DIFF
--- a/src/basic_bot/created_files/src/my_service.py
+++ b/src/basic_bot/created_files/src/my_service.py
@@ -15,7 +15,7 @@ import basic_bot.commons.messages as bb_message
 # HubState is a class that manages the process local copy of the state.
 # Each service runs as a process and  has its own partial or full instance
 # of HubState.
-hub_state = HubState({"worthless_counter": -999})
+hub_state = HubState({"worthless_counter": -999, "worthless_counter_interval": 1.0})
 
 # HubStateMonitor will open a websocket connection to the central hub
 # and start a thread to listen for state changes.  The monitor will call,
@@ -26,7 +26,7 @@ hub_monitor = HubStateMonitor(
     # identity of the service
     "my_service",
     # keys to subscribe to
-    ["worthless_counter", "subsystem_stats"],
+    ["worthless_counter", "worthless_counter_interval", "subsystem_stats"],
     # callback function to call when a message is received
     # Note that when started using bb_start, any standard output or error
     # will be captured and logged to the ./logs directory.
@@ -63,7 +63,8 @@ async def main() -> None:
             await bb_message.send_update_state(
                 hub_monitor.connected_socket, {"worthless_counter": i}
             )
-        await asyncio.sleep(0.01)
+        interval = hub_state.state.get("worthless_counter_interval", 1.0)
+        await asyncio.sleep(interval)
         log.info(f"my_service state: {hub_state.state}")
 
 

--- a/src/basic_bot/created_files/webapp/src/components/WorthlessCounter.module.css
+++ b/src/basic_bot/created_files/webapp/src/components/WorthlessCounter.module.css
@@ -33,3 +33,14 @@
         opacity: 1;
     }
 }
+
+.intervalControl {
+    margin-top: 20px;
+    text-align: center;
+}
+
+.intervalInput {
+    padding: 5px;
+    font-size: 16px;
+    width: 100px;
+}

--- a/src/basic_bot/created_files/webapp/src/components/WorthlessCounter.tsx
+++ b/src/basic_bot/created_files/webapp/src/components/WorthlessCounter.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import { updateSharedState } from "../util/hubState";
 import styles from "./WorthlessCounter.module.css";
 
 interface WorthlessCounterProps {
@@ -5,11 +7,36 @@ interface WorthlessCounterProps {
 }
 
 export function WorthlessCounter({ value }: WorthlessCounterProps) {
+    const [intervalInput, setIntervalInput] = useState<string>("1.0");
+
+    const handleIntervalChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        setIntervalInput(value);
+        const numValue = parseFloat(value);
+        if (!isNaN(numValue) && numValue > 0) {
+            updateSharedState({ worthless_counter_interval: numValue });
+        }
+    };
+
     return (
         <div className={styles.container}>
             <div className={styles.label}>Worthless Counter</div>
             <div className={styles.counter} key={value}>
                 {value ?? "—"}
+            </div>
+            <div className={styles.intervalControl}>
+                <label htmlFor="interval-input">
+                    Update Interval (seconds):{" "}
+                </label>
+                <input
+                    id="interval-input"
+                    type="number"
+                    value={intervalInput}
+                    onChange={handleIntervalChange}
+                    step="0.01"
+                    min="0.01"
+                    className={styles.intervalInput}
+                />
             </div>
         </div>
     );

--- a/src/basic_bot/created_files/webapp/src/util/hubState.ts
+++ b/src/basic_bot/created_files/webapp/src/util/hubState.ts
@@ -41,6 +41,8 @@ export interface IHubState {
 
     // provided by my_service example
     worthless_counter?: number;
+    // consumed by my_service example
+    worthless_counter_interval?: number;
 }
 
 export interface IRecognizedObject {


### PR DESCRIPTION
## Summary
- Adds interactive interval control to WorthlessCounter component
- Demonstrates UI → Hub → Service communication pattern
- Service now reads `worthless_counter_interval` from hub state (default 1.0s)
- Users can adjust counter update speed via number input (min 0.01s, step 0.01s)

## Changes
- **my_service.py**: Subscribe to and use `worthless_counter_interval` from state
- **WorthlessCounter.tsx**: Add interval input control with state update
- **hubState.ts**: Add `worthless_counter_interval` to IHubState interface
- **WorthlessCounter.module.css**: Add styling for interval control

## Test plan
- [x] Run `bb_create test_project` to create new project with updated template
- [x] Start services with `bb_start` 
- [x] Open webapp and verify counter increments every 1 second by default
- [x] Change interval input to different values (e.g., 0.5, 2.0)
- [x] Verify counter speed changes accordingly
- [x] Test with very small intervals (0.01s) and larger intervals (5s)

Resolves #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)